### PR TITLE
fix: Claude セッション更新を Side Panel へ broadcast する (#27)

### DIFF
--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -149,6 +149,18 @@ export class ClaudeSessionWatcher {
 			);
 		}
 		await chrome.storage.local.set({ [STORAGE_KEY]: updated });
+		this.notifySidePanel();
+	}
+
+	/**
+	 * Side Panel に Claude セッション更新を通知する。
+	 * Side Panel が閉じている場合 sendMessage は "Receiving end does not exist" で reject するが、
+	 * これは正常系 (購読者不在) なので意図的に握り潰す。
+	 */
+	private notifySidePanel(): void {
+		chrome.runtime.sendMessage({ type: "CLAUDE_SESSIONS_UPDATED" }).catch(() => {
+			// Side Panel 未起動時の "Receiving end does not exist" は無視する
+		});
 	}
 
 	/**
@@ -187,6 +199,7 @@ export class ClaudeSessionWatcher {
 		}
 
 		await chrome.storage.local.set({ [STORAGE_KEY]: merged });
+		this.notifySidePanel();
 	}
 
 	private async saveSession(session: ClaudeSession): Promise<void> {
@@ -202,6 +215,12 @@ export class ClaudeSessionWatcher {
 		await chrome.storage.local.set({
 			[STORAGE_KEY]: { ...storage, [key]: updatedSessions },
 		});
+		if (import.meta.env.DEV) {
+			console.log(
+				`[DEBUG:watcher] saveSession key=${key} issueNumber=${session.issueNumber} url=${session.sessionUrl}`,
+			);
+		}
+		this.notifySidePanel();
 	}
 
 	private async refreshLiveStatus(): Promise<void> {
@@ -219,5 +238,6 @@ export class ClaudeSessionWatcher {
 		}
 
 		await chrome.storage.local.set({ [STORAGE_KEY]: updated });
+		this.notifySidePanel();
 	}
 }

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -33,3 +33,19 @@ export function isTabUrlChangedEvent(value: unknown): value is TabUrlChangedEven
 	}
 	return obj.url.length > 0;
 }
+
+/**
+ * Background → Side Panel: Claude Code Web セッションの保存内容が更新されたことを通知する。
+ * Side Panel はこれを受信したら getClaudeSessions() を再実行して UI を更新する。
+ */
+export type ClaudeSessionsUpdatedEvent = {
+	readonly type: "CLAUDE_SESSIONS_UPDATED";
+};
+
+export function isClaudeSessionsUpdatedEvent(value: unknown): value is ClaudeSessionsUpdatedEvent {
+	if (value === null || value === undefined || typeof value !== "object") {
+		return false;
+	}
+	const obj = value as Record<string, unknown>;
+	return obj.type === "CLAUDE_SESSIONS_UPDATED";
+}

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -4,7 +4,11 @@
 	import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 	import type { CachedPrData } from "../../shared/types/cache";
 	import type { ClaudeSessionStorage } from "../../shared/types/claude-session";
-	import { isCacheUpdatedEvent, isTabUrlChangedEvent } from "../../shared/types/events";
+	import {
+		isCacheUpdatedEvent,
+		isClaudeSessionsUpdatedEvent,
+		isTabUrlChangedEvent,
+	} from "../../shared/types/events";
 	import { extractPrIssueLinks, movePrsToLinkedIssues } from "../usecase/merge-prs-to-issues";
 	import { mergeSessionsIntoTree } from "../usecase/merge-sessions";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
@@ -186,6 +190,19 @@
 			}
 			if (isTabUrlChangedEvent(message)) {
 				activeTabUrl = message.url;
+			}
+			if (isClaudeSessionsUpdatedEvent(message)) {
+				getClaudeSessions()
+					.then((sessions) => {
+						if (epicData) {
+							epicData = mergeSessionsIntoTree(epicData, sessions);
+						}
+					})
+					.catch((err: unknown) => {
+						if (import.meta.env.DEV) {
+							console.warn("[MainScreen] claude sessions reload failed:", err);
+						}
+					});
 			}
 		}
 

--- a/src/test/background/claude-session-watcher.test.ts
+++ b/src/test/background/claude-session-watcher.test.ts
@@ -57,6 +57,8 @@ describe("ClaudeSessionWatcher", () => {
 		chromeMock.storage.local.get.mockResolvedValue({});
 		chromeMock.storage.local.set.mockResolvedValue(undefined);
 		chromeMock.tabs.query.mockResolvedValue([]);
+		// notifySidePanel から呼ばれる runtime.sendMessage のデフォルトモック (resolve)
+		chromeMock.runtime.sendMessage.mockResolvedValue(undefined);
 		watcher = new ClaudeSessionWatcher();
 	});
 
@@ -413,6 +415,60 @@ describe("ClaudeSessionWatcher", () => {
 
 			const setCall = chromeMock.storage.local.set.mock.calls[0][0];
 			expect(setCall.claudeSessions["2375"]).toBeDefined();
+		});
+	});
+
+	// Issue #27: ストレージ更新後に Side Panel へ broadcast しないと、後から検知された
+	// セッションが UI に反映されない (Side Panel は購読しても通知が来ないため再取得しない)
+	describe("Issue #27 — Side Panel への broadcast", () => {
+		it("onTabUpdated でセッション保存後に CLAUDE_SESSIONS_UPDATED が broadcast される", async () => {
+			watcher.startWatching();
+			const onUpdatedCallback = chromeMock.tabs.onUpdated.addListener.mock.calls[0][0];
+
+			await onUpdatedCallback(
+				1,
+				{ title: "Investigate issue 27 | Claude Code" },
+				{
+					url: "https://claude.ai/code/session_issue27",
+					title: "Investigate issue 27 | Claude Code",
+				},
+			);
+
+			await vi.waitFor(() => {
+				expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+					type: "CLAUDE_SESSIONS_UPDATED",
+				});
+			});
+		});
+
+		it("handleContentScriptSessions の保存後に CLAUDE_SESSIONS_UPDATED が broadcast される", async () => {
+			await watcher.handleContentScriptSessions([
+				{ url: "https://claude.ai/code/session_x", title: "Investigate issue 27" },
+			]);
+
+			expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+				type: "CLAUDE_SESSIONS_UPDATED",
+			});
+		});
+
+		it("Issue 番号抽出に失敗 (保存スキップ) した場合は broadcast されない", async () => {
+			await watcher.handleContentScriptSessions([
+				{ url: "https://claude.ai/code/session_y", title: "no issue number here" },
+			]);
+
+			expect(chromeMock.runtime.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it("Side Panel 未起動で sendMessage が reject しても例外が伝播しない", async () => {
+			chromeMock.runtime.sendMessage.mockRejectedValue(
+				new Error("Could not establish connection. Receiving end does not exist."),
+			);
+
+			await expect(
+				watcher.handleContentScriptSessions([
+					{ url: "https://claude.ai/code/session_z", title: "Investigate issue 27" },
+				]),
+			).resolves.not.toThrow();
 		});
 	});
 });

--- a/src/test/shared/types/events.test.ts
+++ b/src/test/shared/types/events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isCacheUpdatedEvent, isTabUrlChangedEvent } from "../../../shared/types/events";
+import {
+	isCacheUpdatedEvent,
+	isClaudeSessionsUpdatedEvent,
+	isTabUrlChangedEvent,
+} from "../../../shared/types/events";
 
 describe("isCacheUpdatedEvent", () => {
 	it("should return true for a valid CacheUpdatedEvent", () => {
@@ -113,5 +117,26 @@ describe("isTabUrlChangedEvent", () => {
 	it("should return false when url is an empty string", () => {
 		const event = { type: "TAB_URL_CHANGED", url: "" };
 		expect(isTabUrlChangedEvent(event)).toBe(false);
+	});
+});
+
+describe("isClaudeSessionsUpdatedEvent", () => {
+	it("should return true for a valid CLAUDE_SESSIONS_UPDATED event", () => {
+		expect(isClaudeSessionsUpdatedEvent({ type: "CLAUDE_SESSIONS_UPDATED" })).toBe(true);
+	});
+
+	it("should return false when type is different", () => {
+		expect(isClaudeSessionsUpdatedEvent({ type: "CACHE_UPDATED" })).toBe(false);
+	});
+
+	it("should return false for null/undefined/non-object", () => {
+		expect(isClaudeSessionsUpdatedEvent(null)).toBe(false);
+		expect(isClaudeSessionsUpdatedEvent(undefined)).toBe(false);
+		expect(isClaudeSessionsUpdatedEvent("string")).toBe(false);
+		expect(isClaudeSessionsUpdatedEvent(42)).toBe(false);
+	});
+
+	it("should return true even with extra properties", () => {
+		expect(isClaudeSessionsUpdatedEvent({ type: "CLAUDE_SESSIONS_UPDATED", extra: 1 })).toBe(true);
 	});
 });


### PR DESCRIPTION
## 概要

closes #27

watcher が `chrome.storage.local.set` 後に Side Panel へ通知していなかったため、起動後に新しく検知されたセッションが UI に反映されなかった。Side Panel 側にも購読ロジック自体が無く、起動時の `getClaudeSessions()` 1回しか取得していなかった。

## 変更内容

- `src/shared/types/events.ts`: `ClaudeSessionsUpdatedEvent` 型と型ガードを追加
- `src/background/claude-session-watcher.ts`: `notifySidePanel()` ヘルパーを追加し、`saveSession` / `handleContentScriptSessions` / `cleanupClosedIssues` / `refreshLiveStatus` の storage 更新4箇所で呼び出す。Side Panel 未起動時の `"Receiving end does not exist"` は意図的に握り潰す (購読者不在は正常系)。`saveSession` に DEBUG ログを追加し次回調査を容易にする
- `src/sidepanel/components/MainScreen.svelte`: `onMessage` で `isClaudeSessionsUpdatedEvent` を購読、`getClaudeSessions()` を再取得して `mergeSessionsIntoTree` で `epicData` を更新する
- `src/test/shared/types/events.test.ts`: 新しい型ガードのテスト追加
- `src/test/background/claude-session-watcher.test.ts`: Issue #27 regression テスト 4件追加

## 関連 Issue

closes #27

(別件: Chrome のタブ復元で意図と違うセッションが開かれる挙動 → #28 で別途追跡)

## テスト

- [x] vitest unit (52 tests pass、Issue #27 regression 4件含む)
- [x] `pnpm build` 成功
- [x] 実機検証: Side Panel 起動後に新しく Claude Code Web タブを開き、PR Sidebar の該当 Issue 配下に紫ハイライト付きでセッションが即時反映されることを確認 (#2617 で検証)
- [ ] E2E
- [ ] 手動回帰テスト (他 Issue でも同様に動作するか)

## レビュー観点

- `notifySidePanel()` で `sendMessage` の reject を catch で握り潰している箇所: コメントで「購読者不在は正常系」と明示しているが、`agent-output-quality.md` のサイレントフォールバック禁止ルールに抵触しないか確認してほしい
- `MainScreen.svelte` で `mergeSessionsIntoTree(epicData, sessions)` を再呼び出ししているが、`epicData` は既にマージ済みの状態。再マージが冪等であることを前提にしている。問題があれば指摘してほしい
- `cleanupClosedIssues` / `refreshLiveStatus` の broadcast は今回バグの直接原因ではないが、storage が更新される全パスで通知すべきという設計判断で追加した