### PR TITLE
fix(content): claude-session-scraper を React fiber 経由に書き換え

### DIFF
--- a/src/content/claude-session-scraper.ts
+++ b/src/content/claude-session-scraper.ts
@@ -1,45 +1,99 @@
 /**
  * Claude Code Web (claude.ai/code) のセッションリンクを DOM からスクレイプする。
  * Content Script として注入され、セッション一覧を Background に送信する。
+ *
+ * React の内部 fiber ツリー (__reactFiber$<hash>) を走査して session 情報を取得する。
+ * claude.ai は React SPA であり、DOM 属性にセッション ID が露出しないため、
+ * fiber の memoizedProps.session から直接読み取る方式を採用している。
  */
 
-const SESSION_LINK_SELECTOR = 'a[href*="/code/session_"]';
-const SESSION_PATH_PATTERN = /\/code\/session_/;
+const SESSION_CONTAINER_SELECTOR = "div.cursor-pointer";
+const FIBER_KEY_PREFIX = "__reactFiber$";
+const MAX_FIBER_DEPTH = 10;
+const CLAUDE_CODE_BASE_URL = "https://claude.ai/code/";
+/** session.id は session_ + 英数字/ハイフン/アンダースコアのみ許可 (path traversal / query 混入防止) */
+const SESSION_ID_PATTERN = /^session_[a-zA-Z0-9_-]{1,128}$/;
 
 interface SessionLink {
 	readonly url: string;
 	readonly title: string;
 }
 
-/**
- * Document 内のセッションリンク要素から URL とタイトルを抽出する。
- * href が `/code/session_` パターンに一致するリンクのみ対象。
- * 同一 URL の重複は最初の出現のみ保持する。
- */
 /** Content Script から Background へ送信するメッセージ型 */
 interface ContentClaudeSessionsMessage {
 	readonly type: "CONTENT_CLAUDE_SESSIONS";
 	readonly sessions: readonly SessionLink[];
 }
 
+/**
+ * DOM 要素から React fiber のキー名を探す。
+ * React は __reactFiber$<ランダムハッシュ> というプロパティ名で fiber を格納する。
+ * ハッシュ値はページロードごとに固定なので、最初の発見をキャッシュして再利用する。
+ */
+let cachedFiberKey: string | null | undefined;
+
+function findFiberKey(element: Element): string | null {
+	if (cachedFiberKey !== undefined) return cachedFiberKey;
+	const key = Object.keys(element).find((k) => k.startsWith(FIBER_KEY_PREFIX)) ?? null;
+	cachedFiberKey = key;
+	return key;
+}
+
+/**
+ * 要素の fiber ツリーを親方向に走査し、memoizedProps.session を探す。
+ * React fiber は return プロパティで親ノードを辿れる。
+ */
+function extractSessionFromFiber(element: Element): SessionLink | null {
+	// React fiber は外部非公開 API のため型定義が存在しない
+	// biome-ignore lint/suspicious/noExplicitAny: React internal fiber has no public type definitions
+	try {
+		const fiberKey = findFiberKey(element);
+		if (!fiberKey) return null;
+
+		// biome-ignore lint/suspicious/noExplicitAny: React internal fiber has no public type definitions
+		let node = (element as any)[fiberKey];
+		for (let i = 0; i < MAX_FIBER_DEPTH && node; i++) {
+			const session = node.memoizedProps?.session;
+			if (session && typeof session.id === "string" && SESSION_ID_PATTERN.test(session.id)) {
+				return {
+					url: `${CLAUDE_CODE_BASE_URL}${session.id}`,
+					title: typeof session.title === "string" ? session.title.slice(0, 500) : "",
+				};
+			}
+			node = node.return;
+		}
+	} catch (e) {
+		// fiber プロパティへのアクセスが Proxy 等で例外を投げる可能性がある
+		console.error("[claude-session-scraper] fiber extraction failed:", e);
+	}
+	return null;
+}
+
+/**
+ * Document 内の React fiber からセッション情報を抽出する。
+ * 同一 URL の重複は最初の出現のみ保持する。
+ */
 export function scrapeSessionLinks(doc: Document): readonly SessionLink[] {
-	const anchors = doc.querySelectorAll<HTMLAnchorElement>(SESSION_LINK_SELECTOR);
+	// ページロードごとにハッシュが変わるためキャッシュをリセット
+	cachedFiberKey = undefined;
+
+	const rows = doc.querySelectorAll(SESSION_CONTAINER_SELECTOR);
 	const seen = new Set<string>();
 	const results: SessionLink[] = [];
 
-	for (const anchor of anchors) {
-		const href = anchor.getAttribute("href") ?? "";
-		if (!SESSION_PATH_PATTERN.test(href)) continue;
+	for (const row of rows) {
+		const session = extractSessionFromFiber(row);
+		if (!session) continue;
+		if (seen.has(session.url)) continue;
+		seen.add(session.url);
+		results.push(session);
+	}
 
-		// href 属性の生値を使う（相対パスの場合は anchor.href で絶対化される場合がある）
-		const url = anchor.href || href;
-		if (seen.has(url)) continue;
-		seen.add(url);
-
-		results.push({
-			url,
-			title: anchor.textContent?.trim() ?? "",
-		});
+	if (results.length === 0 && doc.location?.href?.includes("claude.ai/code")) {
+		// セレクタや fiber 構造が変更された可能性がある（将来の DOM 改修検知用）
+		console.warn(
+			"[claude-session-scraper] 0 sessions found on claude.ai/code. Selector or fiber structure may have changed.",
+		);
 	}
 
 	return results;

--- a/src/test/content/claude-session-scraper.test.ts
+++ b/src/test/content/claude-session-scraper.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { scrapeSessionLinks } from "../../content/claude-session-scraper";
 
 describe("scrapeSessionLinks", () => {
@@ -9,51 +9,134 @@ describe("scrapeSessionLinks", () => {
 	});
 
 	/**
-	 * DOM ヘルパー: セッションリンク一覧を含むページを構築する。
-	 * claude.ai/code のセッション一覧ページでは、各セッションが
-	 * <a href="/code/session_xxxxx">タイトル</a> 形式で並ぶ想定。
+	 * React fiber ノードを持つ DOM 要素を生成する。
+	 * claude.ai/code ではセッション一覧の各行が React コンポーネントとして
+	 * レンダリングされ、__reactFiber$<hash> プロパティに fiber ツリーが格納される。
+	 * memoizedProps.session にセッション情報が入っている。
 	 */
-	function addSessionLink(href: string, text: string): void {
-		const a = doc.createElement("a");
-		a.href = href;
-		a.textContent = text;
-		doc.body.appendChild(a);
+	function createFiberElement(
+		session: { id: string; title: string },
+		hash = "abc123",
+	): HTMLDivElement {
+		const div = doc.createElement("div");
+		div.className = "cursor-pointer";
+		(div as unknown as Record<string, unknown>)[`__reactFiber$${hash}`] = {
+			memoizedProps: { session },
+			return: null,
+		};
+		return div;
 	}
 
-	it("セッションリンク要素から URL とタイトルを正しく抽出する", () => {
-		addSessionLink("/code/session_01T7hN9fW6KuKZxn52isYdyR", "Investigate issue 2375");
-		addSessionLink("/code/session_abc123def456", "Inv #1882 [#1613] CI/CD App統一");
+	/**
+	 * fiber ツリーが深い階層にある場合をシミュレートする。
+	 * depth=2 なら要素直結の fiber → return → session を持つ fiber の 2 階層。
+	 */
+	function createFiberElementDeep(
+		session: { id: string; title: string },
+		hash = "abc123",
+		depth = 2,
+	): HTMLDivElement {
+		const div = doc.createElement("div");
+		div.className = "cursor-pointer";
+		// 最深部に session を持つ fiber ノードを配置
+		let node: Record<string, unknown> = {
+			memoizedProps: { session },
+			return: null,
+		};
+		// depth-1 回ラップして親方向の階層を作る
+		for (let i = 1; i < depth; i++) {
+			node = { memoizedProps: {}, return: node };
+		}
+		(div as unknown as Record<string, unknown>)[`__reactFiber$${hash}`] = node;
+		return div;
+	}
+
+	it("React fiber の memoizedProps.session から URL とタイトルを正しく抽出する", () => {
+		doc.body.appendChild(
+			createFiberElement({
+				id: "session_01T7hN9fW6KuKZxn52isYdyR",
+				title: "Investigate issue 2375",
+			}),
+		);
+		doc.body.appendChild(
+			createFiberElement({
+				id: "session_abc123def456",
+				title: "CI/CD App統一",
+			}),
+		);
 
 		const result = scrapeSessionLinks(doc);
 
 		expect(result).toHaveLength(2);
 		expect(result[0]).toEqual({
-			url: expect.stringContaining("/code/session_01T7hN9fW6KuKZxn52isYdyR"),
+			url: "https://claude.ai/code/session_01T7hN9fW6KuKZxn52isYdyR",
 			title: "Investigate issue 2375",
 		});
 		expect(result[1]).toEqual({
-			url: expect.stringContaining("/code/session_abc123def456"),
-			title: "Inv #1882 [#1613] CI/CD App統一",
+			url: "https://claude.ai/code/session_abc123def456",
+			title: "CI/CD App統一",
 		});
 	});
 
-	it("href が /code/session_ パターンに一致しないリンクは除外する", () => {
-		// セッションリンク
-		addSessionLink("/code/session_valid123", "Investigate issue 100");
-		// 除外されるべきリンク
-		addSessionLink("/code/scheduled", "Scheduled tasks");
-		addSessionLink("/code", "Claude Code home");
-		addSessionLink("/chat/abc123", "Some chat");
-		addSessionLink("/code/draft_09baa7d1", "Draft session");
+	it("fiber が親方向 2 階層目にある場合も抽出できる", () => {
+		doc.body.appendChild(
+			createFiberElementDeep({ id: "session_deep01", title: "Deep session" }, "abc123", 2),
+		);
 
 		const result = scrapeSessionLinks(doc);
 
 		expect(result).toHaveLength(1);
-		expect(result[0].title).toBe("Investigate issue 100");
+		expect(result[0]).toEqual({
+			url: "https://claude.ai/code/session_deep01",
+			title: "Deep session",
+		});
 	});
 
-	it("DOM にセッションリンクがない場合は空配列を返す", () => {
-		// リンクなし
+	it("fiber が親方向 MAX_FIBER_DEPTH を超える場合は抽出しない", () => {
+		// MAX_FIBER_DEPTH=10 を超える 11 階層
+		doc.body.appendChild(
+			createFiberElementDeep({ id: "session_tooDeep", title: "Too deep" }, "abc123", 11),
+		);
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toEqual([]);
+	});
+
+	it("__reactFiber$ プロパティがない要素はスキップする", () => {
+		const div = doc.createElement("div");
+		div.className = "cursor-pointer";
+		doc.body.appendChild(div);
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toEqual([]);
+	});
+
+	it("session.id が session_ で始まらない場合はスキップする", () => {
+		doc.body.appendChild(createFiberElement({ id: "draft_09baa7d1", title: "Draft" }));
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toEqual([]);
+	});
+
+	it("session プロパティが存在しない fiber はスキップする", () => {
+		const div = doc.createElement("div");
+		div.className = "cursor-pointer";
+		// biome-ignore lint/complexity/useLiteralKeys: fiber キーはテンプレートリテラル形式と統一するためブラケットで記述
+		(div as unknown as Record<string, unknown>)["__reactFiber$abc123"] = {
+			memoizedProps: { onClick: () => {} },
+			return: null,
+		};
+		doc.body.appendChild(div);
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toEqual([]);
+	});
+
+	it("DOM にマッチする要素がない場合は空配列を返す", () => {
 		const p = doc.createElement("p");
 		p.textContent = "No sessions here";
 		doc.body.appendChild(p);
@@ -63,15 +146,53 @@ describe("scrapeSessionLinks", () => {
 		expect(result).toEqual([]);
 	});
 
-	it("同じ URL のリンクが複数ある場合は重複除去する", () => {
-		const href = "/code/session_duplicate123";
-		addSessionLink(href, "Investigate issue 500");
-		addSessionLink(href, "Investigate issue 500");
-		addSessionLink(href, "Investigate issue 500 (copy)");
+	it("同一 session.id の重複は除去する", () => {
+		for (let i = 0; i < 3; i++) {
+			doc.body.appendChild(
+				createFiberElement({
+					id: "session_duplicate123",
+					title: `Copy ${i}`,
+				}),
+			);
+		}
 
 		const result = scrapeSessionLinks(doc);
 
 		expect(result).toHaveLength(1);
-		expect(result[0].url).toContain("/code/session_duplicate123");
+		expect(result[0].url).toBe("https://claude.ai/code/session_duplicate123");
+	});
+
+	it("session.title が undefined の場合は空文字列にフォールバックする", () => {
+		doc.body.appendChild(
+			createFiberElement({ id: "session_noTitle", title: undefined as unknown as string }),
+		);
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe("");
+		expect(result[0].url).toBe("https://claude.ai/code/session_noTitle");
+	});
+
+	it("fiber アクセスで例外が発生しても throw せず空配列を返す", () => {
+		const div = doc.createElement("div");
+		div.className = "cursor-pointer";
+		Object.defineProperty(div, "__reactFiber$abc123", {
+			get() {
+				throw new Error("Simulated fiber access error");
+			},
+			enumerable: true,
+			configurable: true,
+		});
+		doc.body.appendChild(div);
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const result = scrapeSessionLinks(doc);
+
+		expect(result).toEqual([]);
+		expect(errorSpy).toHaveBeenCalled();
+
+		errorSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## 概要
Claude Code Web の DOM 改修 (anchor → div.cursor-pointer) に追従し、content script のセッション取得ロジックを React fiber の `memoizedProps.session` 経由に書き換えた。既存の `a[href*="/code/session_"]` selector は Claude 側 UI 変更で 0 件を返すようになっていた。

## 変更内容
- `src/content/claude-session-scraper.ts`: selector を `div.cursor-pointer` に変更し、React fiber ツリーから `session.id` / `session.title` を抽出する方式に書き換え。session.id の正規表現バリデーション追加 (path traversal 防止)。fiber key キャッシュで `Object.keys()` 呼び出しを最小化。0件時の診断ログ追加
- `src/test/content/claude-session-scraper.test.ts`: fake fiber モックで全面書き直し。10テストケース (正常抽出、深度走査、上限超え、fiber なし、不正 ID、session なし、空 DOM、重複除去、title undefined、例外耐性)

## 関連 Issue
- closes #31
- refs #30 (親 Issue)
- refs #27 (Claude セッション非表示の根本原因)

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 763 PASS
- [ ] Rust lint 通過 (本 PR は TS のみ変更)
- [ ] Rust テスト通過 (本 PR は TS のみ変更)
- [x] `pnpm build` (vite production build) 成功

## レビュー観点
1. **React fiber 非公開 API への依存**: `__reactFiber$<hash>` と `memoizedProps` は React 内部構造。Claude 側の React バージョンアップで壊れる可能性あり。try/catch + 0件診断ログで検知可能にしている
2. **session.id バリデーション**: `SESSION_ID_PATTERN = /^session_[a-zA-Z0-9_-]{1,128}$/` で path traversal / query 混入を防止。claude.ai の実際の session ID 形式と整合しているか
3. **fiber key キャッシュ**: ページロードごとにハッシュは固定のためキャッシュが有効。`scrapeSessionLinks` 呼び出しごとにリセットしている
4. **外側 try/catch の除去**: 個別要素の `extractSessionFromFiber` が try/catch で守られているため、`scrapeSessionLinks` の外側 catch は除去し部分結果の破棄を防止した

## Agent レビュー結果
| 観点 | 結果 | 対応 |
|------|------|------|
| Security | 2 MEDIUM, 2 LOW | session.id 正規表現バリデーション追加 (FIXED) |
| Architecture | 2 懸念 | SessionLink 型 shared 化・session_ チェック位置はスコープ外 |
| Quality | 2 MEDIUM, 3 LOW | 外側 catch 除去・title undefined テスト追加 (FIXED) |
| Performance | 2 MEDIUM, 1 LOW | fiber key キャッシュ追加 (FIXED) |