### PR TITLE
feat: Side Panel デバッグタブ + ログ蓄積 + externally_connectable 追加

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -23,6 +23,9 @@ export default defineManifest({
 			run_at: "document_idle",
 		},
 	],
+	externally_connectable: {
+		matches: ["https://claude.ai/*"],
+	},
 	action: {
 		default_icon: {
 			"16": "icons/icon-16.png",

--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -14,6 +14,7 @@ import { WasmEpicProcessor } from "../wasm/epic-processor";
 import { WasmIssueProcessor } from "../wasm/issue-processor";
 import { WasmPrProcessor } from "../wasm/pr-processor";
 import { ClaudeSessionWatcher } from "./claude-session-watcher";
+import { createExternalMessageHandler } from "./external-message-handler";
 import { createMessageHandler } from "./message-handler";
 import type { AppServices } from "./types";
 import { createWorkspaceOpenUseCase } from "./workspace-open.usecase";
@@ -76,6 +77,10 @@ export function initializeApp(): AppServices {
 		workspaceOpen,
 	});
 	chrome.runtime.onMessage.addListener(handler);
+
+	// claude.ai からの外部メッセージを受け付ける (externally_connectable)
+	const externalHandler = createExternalMessageHandler(claudeSessionWatcher);
+	chrome.runtime.onMessageExternal.addListener(externalHandler);
 
 	// タブ変更リスナー: アクティブタブの URL 変更を Side Panel に通知
 	async function onTabActivated(activeInfo: { tabId: number; windowId: number }): Promise<void> {

--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -1,4 +1,5 @@
 import type { ClaudeSession, ClaudeSessionStorage } from "../shared/types/claude-session";
+import { logDebug } from "../shared/utils/debug-logger";
 
 const CLAUDE_CODE_URL_PATTERN = "claude.ai/code/";
 const STORAGE_KEY = "claudeSessions";
@@ -56,13 +57,19 @@ export class ClaudeSessionWatcher {
 				if (!isContentSessionsMessage(message)) return;
 				this.handleContentScriptSessions(message.sessions).catch((err: unknown) => {
 					console.error("[DEBUG:watcher] handleContentScriptSessions failed:", err);
+					// ログ書き込み自体が失敗してもメイン処理に影響させない
+					logDebug("error", "watcher", "handleContentScriptSessions failed", String(err)).catch(
+						() => {},
+					);
 				});
 			},
 		);
 
 		// 起動時に既に開いている Claude Code Web タブを検出
-		this.scanExistingTabs().catch(() => {
+		this.scanExistingTabs().catch((err: unknown) => {
 			// スキャン失敗は非致命的（次の onUpdated で拾える）
+			// ログ書き込み自体が失敗してもメイン処理に影響させない
+			logDebug("warn", "watcher", "scanExistingTabs failed", String(err)).catch(() => {});
 		});
 	}
 

--- a/src/background/external-message-handler.ts
+++ b/src/background/external-message-handler.ts
@@ -1,0 +1,46 @@
+import type { DebugState } from "../shared/types/messages";
+import { getDebugEntries } from "../shared/utils/debug-logger";
+import type { ClaudeSessionWatcher } from "./claude-session-watcher";
+
+/**
+ * claude.ai からの外部メッセージを処理する (externally_connectable)。
+ * ホワイトリスト方式で GET_DEBUG_STATE のみ許可する。
+ */
+export function createExternalMessageHandler(claudeSessionWatcher: ClaudeSessionWatcher) {
+	return (
+		message: unknown,
+		sender: chrome.runtime.MessageSender,
+		sendResponse: (response: unknown) => void,
+	): boolean => {
+		if (!sender.url?.startsWith("https://claude.ai/")) {
+			sendResponse({ ok: false, error: "Unauthorized origin" });
+			return true;
+		}
+		if (
+			typeof message !== "object" ||
+			message === null ||
+			(message as { type?: string }).type !== "GET_DEBUG_STATE"
+		) {
+			sendResponse({ ok: false, error: "Unsupported message type" });
+			return true;
+		}
+		(async () => {
+			try {
+				const claudeSessions = await claudeSessionWatcher.getSessions();
+				const logs = await getDebugEntries();
+				const tabs = await chrome.tabs.query({ url: "*://claude.ai/code/*" });
+				const debugState: DebugState = {
+					claudeSessions,
+					watcherTabCount: tabs.length,
+					logs,
+				};
+				sendResponse({ ok: true, data: debugState });
+			} catch (e: unknown) {
+				console.error("[external-message-handler] error:", e);
+				sendResponse({ ok: false, error: String(e) });
+			}
+		})();
+		// 非同期レスポンスを返すために true を返す
+		return true;
+	};
+}

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -1,5 +1,11 @@
-import type { MessageType, RequestMessage, ResponseMessage } from "../shared/types/messages";
+import type {
+	DebugState,
+	MessageType,
+	RequestMessage,
+	ResponseMessage,
+} from "../shared/types/messages";
 import { isRequestMessage } from "../shared/types/messages";
+import { getDebugEntries } from "../shared/utils/debug-logger";
 import { extractPrBaseUrl, isPrSubPage } from "../shared/utils/github-url";
 import type { ClaudeSessionWatcher } from "./claude-session-watcher";
 import type { AppServices } from "./types";
@@ -16,6 +22,7 @@ const ERROR_MESSAGES: Record<MessageType, string> = {
 	UPDATE_BADGE: "Failed to update badge",
 	NAVIGATE_TO_PR: "Navigation failed",
 	GET_CLAUDE_SESSIONS: "Failed to get Claude sessions",
+	GET_DEBUG_STATE: "Failed to get debug state",
 	OPEN_WORKSPACE: "Failed to open workspace",
 };
 
@@ -216,6 +223,18 @@ async function handleMessage(
 			case "GET_CLAUDE_SESSIONS": {
 				const sessions = await services.claudeSessionWatcher.getSessions();
 				sendResponse({ ok: true, data: sessions });
+				break;
+			}
+			case "GET_DEBUG_STATE": {
+				const claudeSessions = await services.claudeSessionWatcher.getSessions();
+				const logs = await getDebugEntries();
+				const tabs = await chrome.tabs.query({ url: "*://claude.ai/code/*" });
+				const debugState: DebugState = {
+					claudeSessions,
+					watcherTabCount: tabs.length,
+					logs,
+				};
+				sendResponse({ ok: true, data: debugState });
 				break;
 			}
 			case "OPEN_WORKSPACE": {

--- a/src/content/claude-session-scraper.ts
+++ b/src/content/claude-session-scraper.ts
@@ -7,6 +7,8 @@
  * fiber の memoizedProps.session から直接読み取る方式を採用している。
  */
 
+import { logDebug } from "../shared/utils/debug-logger";
+
 const SESSION_CONTAINER_SELECTOR = "div.cursor-pointer";
 const FIBER_KEY_PREFIX = "__reactFiber$";
 const MAX_FIBER_DEPTH = 10;
@@ -65,6 +67,8 @@ function extractSessionFromFiber(element: Element): SessionLink | null {
 	} catch (e) {
 		// fiber プロパティへのアクセスが Proxy 等で例外を投げる可能性がある
 		console.error("[claude-session-scraper] fiber extraction failed:", e);
+		// Content Script では chrome.storage が利用不可な場合があるため fire-and-forget
+		logDebug("error", "scraper", "fiber extraction failed", String(e)).catch(() => {});
 	}
 	return null;
 }
@@ -94,6 +98,12 @@ export function scrapeSessionLinks(doc: Document): readonly SessionLink[] {
 		console.warn(
 			"[claude-session-scraper] 0 sessions found on claude.ai/code. Selector or fiber structure may have changed.",
 		);
+		// Content Script では chrome.storage が利用不可な場合があるため fire-and-forget
+		logDebug(
+			"warn",
+			"scraper",
+			"0 sessions found — selector or fiber structure may have changed",
+		).catch(() => {});
 	}
 
 	return results;
@@ -112,6 +122,8 @@ function sendSessionsToBackground(): void {
 	// fire-and-forget: Background 側で受信処理する
 	chrome.runtime.sendMessage(message).catch((err: unknown) => {
 		console.error("[claude-session-scraper] sendMessage failed:", err);
+		// Content Script では chrome.storage が利用不可な場合があるため fire-and-forget
+		logDebug("error", "scraper", "sendMessage failed", String(err)).catch(() => {});
 	});
 }
 

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -2,7 +2,14 @@ import type { EpicTreeDto } from "../../domain/ports/epic-processor.port";
 import type { IssueListDto } from "../../domain/ports/issue-processor.port";
 import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
+import type { DebugLogEntry } from "../utils/debug-logger";
 import type { ClaudeSessionStorage } from "./claude-session";
+
+export interface DebugState {
+	readonly claudeSessions: ClaudeSessionStorage;
+	readonly watcherTabCount: number;
+	readonly logs: readonly DebugLogEntry[];
+}
 
 export const MESSAGE_TYPES = [
 	"AUTH_LOGOUT",
@@ -15,6 +22,7 @@ export const MESSAGE_TYPES = [
 	"UPDATE_BADGE",
 	"NAVIGATE_TO_PR",
 	"GET_CLAUDE_SESSIONS",
+	"GET_DEBUG_STATE",
 	"OPEN_WORKSPACE",
 ] as const;
 
@@ -32,6 +40,7 @@ export type RequestMap = {
 	UPDATE_BADGE: { reviewRequestCount: number };
 	NAVIGATE_TO_PR: { url: string };
 	GET_CLAUDE_SESSIONS: undefined;
+	GET_DEBUG_STATE: undefined;
 	OPEN_WORKSPACE: {
 		issueNumber: number;
 		issueUrl: string;
@@ -53,6 +62,7 @@ export type ResponseDataMap = {
 	UPDATE_BADGE: undefined;
 	NAVIGATE_TO_PR: undefined;
 	GET_CLAUDE_SESSIONS: ClaudeSessionStorage;
+	GET_DEBUG_STATE: DebugState;
 	OPEN_WORKSPACE: undefined;
 };
 

--- a/src/shared/utils/debug-logger.ts
+++ b/src/shared/utils/debug-logger.ts
@@ -1,0 +1,37 @@
+export interface DebugLogEntry {
+	readonly timestamp: string;
+	readonly level: "info" | "warn" | "error";
+	readonly source: string;
+	readonly message: string;
+	readonly detail?: string;
+}
+
+const STORAGE_KEY = "debugLogs";
+const MAX_LOG_ENTRIES = 100;
+
+export async function logDebug(
+	level: DebugLogEntry["level"],
+	source: string,
+	message: string,
+	detail?: string,
+): Promise<void> {
+	const entry: DebugLogEntry = {
+		timestamp: new Date().toISOString(),
+		level,
+		source,
+		message,
+		detail,
+	};
+	const entries = await getDebugEntries();
+	const updated = [...entries, entry].slice(-MAX_LOG_ENTRIES);
+	await chrome.storage.local.set({ [STORAGE_KEY]: updated });
+}
+
+export async function getDebugEntries(): Promise<readonly DebugLogEntry[]> {
+	const result = await chrome.storage.local.get(STORAGE_KEY);
+	return (result[STORAGE_KEY] as DebugLogEntry[] | undefined) ?? [];
+}
+
+export async function clearDebugEntries(): Promise<void> {
+	await chrome.storage.local.remove(STORAGE_KEY);
+}

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -7,6 +7,7 @@
 	import type { createAuthUseCase } from "../shared/usecase/auth.usecase.js";
 	import type { createPrUseCase } from "../shared/usecase/pr.usecase.js";
 	import type { DeviceFlowController } from "../shared/usecase/device-flow.controller.js";
+	import type { DebugState } from "../shared/types/messages";
 	import type { WorkspaceResources } from "../shared/utils/workspace-resources";
 	import type { PinnedTabsStore } from "./stores/pinned-tabs.svelte";
 
@@ -21,8 +22,9 @@
 		onNavigate?: (url: string) => void;
 		onOpenWorkspace?: (resources: WorkspaceResources) => void;
 		getCurrentTabUrl?: () => Promise<string | null>;
+		getDebugState?: () => Promise<DebugState>;
 	};
-	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, deviceFlowController, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl }: Props = $props();
+	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, deviceFlowController, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
 
 	let authenticated = $state(false);
 	let loading = $state(true);
@@ -62,7 +64,7 @@
 		<p>Loading...</p>
 	</div>
 {:else if authenticated}
-	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} />
+	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} {getDebugState} />
 {:else}
 	<LoginScreen controller={deviceFlowController} />
 {/if}

--- a/src/sidepanel/components/DebugPanel.svelte
+++ b/src/sidepanel/components/DebugPanel.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import type { DebugState } from "../../shared/types/messages";
+
+  interface Props {
+    getDebugState: () => Promise<DebugState>;
+  }
+
+  const { getDebugState }: Props = $props();
+
+  let debugState = $state<DebugState | null>(null);
+  let loading = $state(false);
+  let copied = $state(false);
+
+  async function refresh(): Promise<void> {
+    loading = true;
+    try {
+      debugState = await getDebugState();
+    } catch (e: unknown) {
+      console.error("Failed to load debug state:", e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function copyToClipboard(): Promise<void> {
+    if (!debugState) return;
+    await navigator.clipboard.writeText(JSON.stringify(debugState, null, 2));
+    copied = true;
+    setTimeout(() => {
+      copied = false;
+    }, 2000);
+  }
+
+  $effect(() => {
+    refresh();
+  });
+</script>
+
+<div class="debug-panel">
+  <div class="debug-header">
+    <h3>Debug</h3>
+    <div class="debug-actions">
+      <button onclick={refresh} disabled={loading}>Refresh</button>
+      <button onclick={copyToClipboard} disabled={!debugState}>
+        {copied ? "Copied!" : "Copy"}
+      </button>
+    </div>
+  </div>
+
+  {#if debugState}
+    <section>
+      <h4>Watcher</h4>
+      <p>Monitoring tabs: {debugState.watcherTabCount}</p>
+    </section>
+
+    <section>
+      <h4>Claude Sessions</h4>
+      <pre class="debug-json">{JSON.stringify(debugState.claudeSessions, null, 2)}</pre>
+    </section>
+
+    <section>
+      <h4>Logs ({debugState.logs.length})</h4>
+      {#if debugState.logs.length === 0}
+        <p class="empty">No logs</p>
+      {:else}
+        <div class="log-list">
+          {#each debugState.logs as entry, i (entry.timestamp + i)}
+            <div class="log-entry log-{entry.level}">
+              <span class="log-time">{entry.timestamp.slice(11, 19)}</span>
+              <span class="log-level">{entry.level}</span>
+              <span class="log-source">{entry.source}</span>
+              <span class="log-msg">{entry.message}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {:else if loading}
+    <p>Loading...</p>
+  {/if}
+</div>
+
+<style>
+  .debug-panel {
+    padding: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .debug-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  h3 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+
+  .debug-actions {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .debug-actions button {
+    padding: 0.125rem 0.5rem;
+    font-size: 0.7rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 3px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+  }
+
+  .debug-actions button:hover:not(:disabled) {
+    color: var(--color-accent-primary);
+    border-color: var(--color-accent-primary);
+  }
+
+  .debug-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  section {
+    margin-bottom: 0.75rem;
+  }
+
+  h4 {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    margin: 0 0 0.25rem;
+    border-bottom: 1px solid var(--color-border-primary);
+    padding-bottom: 0.125rem;
+  }
+
+  .debug-json {
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 3px;
+    padding: 0.375rem;
+    font-size: 0.65rem;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    overflow-x: auto;
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .empty {
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .log-list {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid var(--color-border-primary);
+    border-radius: 3px;
+  }
+
+  .log-entry {
+    display: flex;
+    gap: 0.375rem;
+    padding: 0.125rem 0.375rem;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.65rem;
+    border-bottom: 1px solid var(--color-border-primary);
+  }
+
+  .log-entry:last-child {
+    border-bottom: none;
+  }
+
+  .log-time {
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+  }
+
+  .log-level {
+    flex-shrink: 0;
+    font-weight: 600;
+    min-width: 2.5rem;
+  }
+
+  .log-source {
+    color: var(--color-accent-primary);
+    flex-shrink: 0;
+  }
+
+  .log-msg {
+    color: var(--color-text-primary);
+    word-break: break-all;
+  }
+
+  .log-info .log-level {
+    color: var(--color-accent-primary);
+  }
+
+  .log-warn .log-level {
+    color: var(--color-badge-yellow);
+  }
+
+  .log-error .log-level {
+    color: var(--color-badge-red);
+  }
+</style>

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -18,6 +18,8 @@
 	import EpicTabBar from "./EpicTabBar.svelte";
 	import LogoutButton from "./LogoutButton.svelte";
 	import RelativeTime from "./RelativeTime.svelte";
+	import type { DebugState } from "../../shared/types/messages";
+	import DebugPanel from "./DebugPanel.svelte";
 	import PrSection from "./PrSection.svelte";
 
 	type Props = {
@@ -32,9 +34,12 @@
 		onNavigate?: (url: string) => void;
 		onOpenWorkspace?: (resources: WorkspaceResources) => void;
 		getCurrentTabUrl?: () => Promise<string | null>;
+		getDebugState?: () => Promise<DebugState>;
 	};
 
-	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl }: Props = $props();
+	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+
+	let showDebugPanel = $state(false);
 
 	function handlePin(tab: { type: "epic" | "issue"; number: number; title: string }): void {
 		void pinnedTabsStore.pin(tab);
@@ -236,6 +241,18 @@
 			{#if lastUpdatedAt}
 				<span class="last-updated"><RelativeTime dateStr={lastUpdatedAt} /></span>
 			{/if}
+			{#if getDebugState}
+				<button
+					class="debug-toggle"
+					class:active={showDebugPanel}
+					onclick={() => { showDebugPanel = !showDebugPanel; }}
+					aria-label="Toggle debug panel"
+				>
+					<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+						<path d="M4.978.855a.5.5 0 1 0-.956.29l.41 1.352A4.985 4.985 0 0 0 3 6h10a4.985 4.985 0 0 0-1.432-3.503l.41-1.352a.5.5 0 1 0-.956-.29l-.291.956A4.978 4.978 0 0 0 8 1a4.979 4.979 0 0 0-2.731.811l-.29-.956zM13 6v1H8.5V3.556a4.024 4.024 0 0 1 2.231.811l.291-.956zM6 .278l.291.956A4.028 4.028 0 0 0 4.018 3.5L3 6v1h4.5V3.556A4.094 4.094 0 0 1 6 .278zM1 8.5A.5.5 0 0 1 1.5 8H6v4a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5H1.5a.5.5 0 0 1-.5-.5zm9.5-.5H15a.5.5 0 0 1 0 1h-1.5V12a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1V8.5z"/>
+					</svg>
+				</button>
+			{/if}
 			<LogoutButton {onLogout} />
 		</div>
 	</header>
@@ -259,6 +276,10 @@
 		<EpicTabBar store={pinnedTabsStore} />
 		<EpicSection tree={displayedTree} onPin={handlePin} {onNavigate} onOpenWorkspace={handleOpenWorkspace} {activeTabUrl} {activeWorkspaceIssueNumber} />
 		<PrSection title="Review Requests" items={data.reviewRequests.items} {onNavigate} {activeTabUrl} />
+	{/if}
+
+	{#if showDebugPanel && getDebugState}
+		<DebugPanel {getDebugState} />
 	{/if}
 </main>
 
@@ -383,5 +404,30 @@
 
 	.retry-button:active {
 		opacity: 0.7;
+	}
+
+	.debug-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		background: none;
+		border: 1px solid transparent;
+		border-radius: 3px;
+		cursor: pointer;
+		color: var(--color-text-secondary);
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.debug-toggle:hover {
+		color: var(--color-accent-primary);
+		border-color: var(--color-border-primary);
+	}
+
+	.debug-toggle.active {
+		color: var(--color-accent-primary);
+		border-color: var(--color-accent-primary);
 	}
 </style>

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -5,6 +5,7 @@ import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
 import { TabNavigationAdapter } from "../adapter/chrome/tab-navigation.adapter";
 import type { EpicTreeDto } from "../domain/ports/epic-processor.port";
 import type { ClaudeSessionStorage } from "../shared/types/claude-session";
+import type { DebugState } from "../shared/types/messages";
 import { createAuthUseCase } from "../shared/usecase/auth.usecase";
 import { createDeviceFlowController } from "../shared/usecase/device-flow.controller";
 import { createPrUseCase } from "../shared/usecase/pr.usecase";
@@ -53,6 +54,14 @@ async function getClaudeSessions(): Promise<ClaudeSessionStorage> {
 	return response.data;
 }
 
+async function getDebugState(): Promise<DebugState> {
+	const response = await chromeSendMessage("GET_DEBUG_STATE");
+	if (!response.ok) {
+		throw new Error(response.error.message);
+	}
+	return response.data;
+}
+
 const app = mount(App, {
 	target,
 	props: {
@@ -78,6 +87,7 @@ const app = mount(App, {
 			}
 		},
 		getCurrentTabUrl: () => tabNavigationAdapter.getCurrentTabUrl(),
+		getDebugState,
 	},
 });
 

--- a/src/test/background/external-message-handler.test.ts
+++ b/src/test/background/external-message-handler.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExternalMessageHandler } from "../../background/external-message-handler";
+import { getChromeMock, resetChromeMock, setupChromeMock } from "../mocks/chrome.mock";
+
+describe("createExternalMessageHandler", () => {
+	let mockClaudeSessionWatcher: {
+		getSessions: ReturnType<typeof vi.fn>;
+	};
+	let handler: ReturnType<typeof createExternalMessageHandler>;
+	let storageData: Record<string, unknown>;
+
+	beforeEach(() => {
+		const chromeMock = setupChromeMock();
+		storageData = {};
+
+		chromeMock.storage.local.get.mockImplementation(async (key: string) => {
+			return { [key]: storageData[key] };
+		});
+		chromeMock.tabs.query.mockResolvedValue([{ url: "https://claude.ai/code/session_1" }]);
+
+		mockClaudeSessionWatcher = {
+			getSessions: vi.fn().mockResolvedValue({ "10": [] }),
+		};
+		handler = createExternalMessageHandler(
+			mockClaudeSessionWatcher as unknown as Parameters<typeof createExternalMessageHandler>[0],
+		);
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		vi.restoreAllMocks();
+	});
+
+	it("claude.ai からの GET_DEBUG_STATE に DebugState で応答する", async () => {
+		const sendResponse = vi.fn();
+		const sender = { url: "https://claude.ai/code/session_abc" } as chrome.runtime.MessageSender;
+
+		const result = handler({ type: "GET_DEBUG_STATE" }, sender, sendResponse);
+		expect(result).toBe(true);
+
+		await vi.waitFor(() => {
+			expect(sendResponse).toHaveBeenCalled();
+		});
+
+		const response = sendResponse.mock.calls[0][0] as { ok: boolean; data?: unknown };
+		expect(response.ok).toBe(true);
+		if (response.ok) {
+			const data = response.data as { watcherTabCount: number; logs: unknown[] };
+			expect(data.watcherTabCount).toBe(1);
+			expect(Array.isArray(data.logs)).toBe(true);
+		}
+	});
+
+	it("不正オリジンを拒否する", () => {
+		const sendResponse = vi.fn();
+		const sender = { url: "https://evil.com/page" } as chrome.runtime.MessageSender;
+
+		const result = handler({ type: "GET_DEBUG_STATE" }, sender, sendResponse);
+		expect(result).toBe(true);
+
+		expect(sendResponse).toHaveBeenCalledWith({
+			ok: false,
+			error: "Unauthorized origin",
+		});
+	});
+
+	it("不正メッセージ型を拒否する", () => {
+		const sendResponse = vi.fn();
+		const sender = { url: "https://claude.ai/code/session_abc" } as chrome.runtime.MessageSender;
+
+		const result = handler({ type: "MALICIOUS_TYPE" }, sender, sendResponse);
+		expect(result).toBe(true);
+
+		expect(sendResponse).toHaveBeenCalledWith({
+			ok: false,
+			error: "Unsupported message type",
+		});
+	});
+
+	it("null メッセージを拒否する", () => {
+		const sendResponse = vi.fn();
+		const sender = { url: "https://claude.ai/code/session_abc" } as chrome.runtime.MessageSender;
+
+		const result = handler(null, sender, sendResponse);
+		expect(result).toBe(true);
+
+		expect(sendResponse).toHaveBeenCalledWith({
+			ok: false,
+			error: "Unsupported message type",
+		});
+	});
+
+	it("内部エラー時にエラーレスポンスを返す", async () => {
+		mockClaudeSessionWatcher.getSessions.mockRejectedValue(new Error("Storage broke"));
+		const sendResponse = vi.fn();
+		const sender = { url: "https://claude.ai/code/session_abc" } as chrome.runtime.MessageSender;
+
+		handler({ type: "GET_DEBUG_STATE" }, sender, sendResponse);
+
+		await vi.waitFor(() => {
+			expect(sendResponse).toHaveBeenCalled();
+		});
+
+		const response = sendResponse.mock.calls[0][0] as { ok: boolean; error?: string };
+		expect(response.ok).toBe(false);
+		expect(response.error).toContain("Storage broke");
+	});
+});

--- a/src/test/background/message-handler.test.ts
+++ b/src/test/background/message-handler.test.ts
@@ -875,4 +875,79 @@ describe("createMessageHandler", () => {
 			expect(response).toEqual({ ok: true, data: undefined });
 		});
 	});
+
+	describe("GET_DEBUG_STATE", () => {
+		let mockClaudeSessionWatcher: {
+			getSessions: ReturnType<typeof vi.fn>;
+		};
+		/** chrome.storage.local のインメモリストア */
+		let storageData: Record<string, unknown>;
+
+		beforeEach(() => {
+			const chromeMock = getChromeMock();
+			storageData = {};
+			chromeMock.storage.local.get.mockImplementation(async (key: string) => {
+				return { [key]: storageData[key] };
+			});
+			chromeMock.tabs.query.mockResolvedValue([
+				{ url: "https://claude.ai/code/session_1" },
+				{ url: "https://claude.ai/code/session_2" },
+			]);
+
+			mockClaudeSessionWatcher = {
+				getSessions: vi.fn().mockResolvedValue({
+					"42": [
+						{
+							sessionUrl: "https://claude.ai/code/session_1",
+							title: "Inv #42 debug",
+							issueNumber: 42,
+							detectedAt: "2026-04-08T00:00:00Z",
+							isLive: true,
+						},
+					],
+				}),
+			};
+			services = {
+				auth: mockAuth,
+				claudeSessionWatcher: mockClaudeSessionWatcher,
+			} as unknown as AppServices;
+			handler = createMessageHandler(services);
+		});
+
+		it("GET_DEBUG_STATE: DebugState を返す", async () => {
+			const sendResponse = vi.fn();
+
+			handler({ type: "GET_DEBUG_STATE" }, createTrustedSender(), sendResponse);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(true);
+			if (response.ok) {
+				expect(response.data.watcherTabCount).toBe(2);
+				expect(response.data.claudeSessions).toHaveProperty("42");
+				expect(Array.isArray(response.data.logs)).toBe(true);
+			}
+		});
+
+		it("GET_DEBUG_STATE: 内部エラー時にエラーレスポンスを返す", async () => {
+			mockClaudeSessionWatcher.getSessions.mockRejectedValue(new Error("Storage read failed"));
+			const sendResponse = vi.fn();
+
+			handler({ type: "GET_DEBUG_STATE" }, createTrustedSender(), sendResponse);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(false);
+			if (!response.ok) {
+				expect(response.error.code).toBe("GET_DEBUG_STATE_ERROR");
+				expect(response.error.message).toContain("Failed to get debug state");
+			}
+		});
+	});
 });

--- a/src/test/mocks/chrome.mock.ts
+++ b/src/test/mocks/chrome.mock.ts
@@ -23,6 +23,10 @@ type ChromeMock = {
 			addListener: ReturnType<typeof vi.fn>;
 			removeListener: ReturnType<typeof vi.fn>;
 		};
+		onMessageExternal: {
+			addListener: ReturnType<typeof vi.fn>;
+			removeListener: ReturnType<typeof vi.fn>;
+		};
 		onSuspend: {
 			addListener: ReturnType<typeof vi.fn>;
 			removeListener: ReturnType<typeof vi.fn>;
@@ -96,6 +100,10 @@ function createChromeMock(): ChromeMock {
 			id: "test-extension-id",
 			sendMessage: vi.fn(),
 			onMessage: {
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+			},
+			onMessageExternal: {
 				addListener: vi.fn(),
 				removeListener: vi.fn(),
 			},

--- a/src/test/shared/types/messages.test.ts
+++ b/src/test/shared/types/messages.test.ts
@@ -14,8 +14,9 @@ describe("messages", () => {
 			expect(MESSAGE_TYPES).toContain("NAVIGATE_TO_PR");
 			expect(MESSAGE_TYPES).toContain("FETCH_EPIC_TREE");
 			expect(MESSAGE_TYPES).toContain("GET_CLAUDE_SESSIONS");
+			expect(MESSAGE_TYPES).toContain("GET_DEBUG_STATE");
 			expect(MESSAGE_TYPES).toContain("OPEN_WORKSPACE");
-			expect(MESSAGE_TYPES).toHaveLength(11);
+			expect(MESSAGE_TYPES).toHaveLength(12);
 		});
 	});
 

--- a/src/test/shared/utils/debug-logger.test.ts
+++ b/src/test/shared/utils/debug-logger.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearDebugEntries, getDebugEntries, logDebug } from "../../../shared/utils/debug-logger";
+import { resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+describe("debug-logger", () => {
+	/** chrome.storage.local のインメモリストア */
+	let storageData: Record<string, unknown>;
+
+	beforeEach(() => {
+		const mock = setupChromeMock();
+		storageData = {};
+
+		mock.storage.local.get.mockImplementation(async (key: string) => {
+			return { [key]: storageData[key] };
+		});
+		mock.storage.local.set.mockImplementation(async (items: Record<string, unknown>) => {
+			Object.assign(storageData, items);
+		});
+		mock.storage.local.remove.mockImplementation(async (key: string) => {
+			delete storageData[key];
+		});
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		vi.restoreAllMocks();
+	});
+
+	it("log() はエントリを chrome.storage.local に保存する", async () => {
+		await logDebug("info", "test-source", "hello");
+
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(1);
+		expect(entries[0].source).toBe("test-source");
+		expect(entries[0].message).toBe("hello");
+	});
+
+	it("getEntries() は保存されたエントリ配列を返す", async () => {
+		await logDebug("info", "src-a", "msg-1");
+		await logDebug("warn", "src-b", "msg-2");
+
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(2);
+		expect(entries[0].message).toBe("msg-1");
+		expect(entries[1].message).toBe("msg-2");
+	});
+
+	it("100件を超えたとき最も古いエントリが削除される（リングバッファ動作）", async () => {
+		for (let i = 0; i < 105; i++) {
+			await logDebug("info", "bulk", `msg-${i}`);
+		}
+
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(100);
+		// 最も古い 0-4 は削除され、5 が先頭になる
+		expect(entries[0].message).toBe("msg-5");
+		expect(entries[99].message).toBe("msg-104");
+	});
+
+	it("clear() は全エントリを削除する", async () => {
+		await logDebug("info", "src", "will be cleared");
+		await clearDebugEntries();
+
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(0);
+	});
+
+	it("log() のエントリに timestamp, level, source, message が含まれる", async () => {
+		await logDebug("error", "my-source", "something broke", "detail info");
+
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(1);
+		const entry = entries[0];
+		expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		expect(entry.level).toBe("error");
+		expect(entry.source).toBe("my-source");
+		expect(entry.message).toBe("something broke");
+		expect(entry.detail).toBe("detail info");
+	});
+
+	it("getEntries() は storage が空のとき空配列を返す", async () => {
+		const entries = await getDebugEntries();
+		expect(entries).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## 概要
拡張の検証・デバッグ時に DevTools を開いて Console コマンドを手動実行するコストを削減する。3施策を一括実装。

## 変更内容
### 施策A: Side Panel デバッグパネル
- `src/sidepanel/components/DebugPanel.svelte`: 新規。storage 中身・watcher 状態・ログ一覧を表示。クリップボードコピーボタン付き
- `src/sidepanel/components/MainScreen.svelte`: ヘッダーにデバッグトグルボタン追加
- `src/background/message-handler.ts`: `GET_DEBUG_STATE` ハンドラ追加
- `src/shared/types/messages.ts`: `DebugState` 型 + メッセージ型追加
- `src/sidepanel/App.svelte`, `src/sidepanel/main.ts`: `getDebugState` prop 透過

### 施策B: DebugLogger
- `src/shared/utils/debug-logger.ts`: 新規。リングバッファ式ログ蓄積 (最新100件、chrome.storage.local 永続化)
- `src/background/claude-session-watcher.ts`: エラーハンドラに logDebug 追加
- `src/content/claude-session-scraper.ts`: エラー/警告ハンドラに logDebug 追加

### 施策C: externally_connectable
- `manifest.config.ts`: `externally_connectable: { matches: ["https://claude.ai/*"] }` 追加
- `src/background/external-message-handler.ts`: 新規。claude.ai からの GET_DEBUG_STATE のみ受付するホワイトリスト方式ハンドラ
- `src/background/bootstrap.ts`: onMessageExternal リスナー登録

## 関連 Issue
- closes #35

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`) — 0 errors
- [x] フロントエンドテスト通過 (`pnpm test`) — 776 PASS (+13 新規テスト)
- [ ] Rust lint 通過 (本 PR は TS のみ変更)
- [ ] Rust テスト通過 (本 PR は TS のみ変更)
- [x] `pnpm build` (vite production build) 成功

## レビュー観点
1. **externally_connectable のセキュリティ**: claude.ai のみ許可 + GET_DEBUG_STATE ホワイトリスト方式。将来的に認証系メッセージを誤って許可しないか
2. **DebugLogger の storage 競合**: Background と Content Script が同時に chrome.storage.local に書き込む可能性。get-modify-set の間に書き込みが入るとログが失われうるが、致命的ではない
3. **DebugPanel の UX**: 歯車ボタンの位置・トグル動作。プロダクション環境で常に表示すべきか DEV のみにすべきか
4. **logDebug の fire-and-forget パターン**: Content Script で `.catch(() => {})` を使用。chrome.storage 未定義時の Unhandled Rejection 防止だが、ログ書き込み失敗が無音になるリスク