### PR TITLE
fix: 同一 sessionUrl の cross-issue 重複排除で each_key_duplicate 解消

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -5,6 +5,26 @@ const CLAUDE_CODE_URL_PATTERN = "claude.ai/code/";
 const STORAGE_KEY = "claudeSessions";
 
 /**
+ * 同一 sessionUrl が別の Issue key に既存の場合、その key から削除する。
+ * セッションタイトル変更で Issue 番号が変わるケースへの対応 (Issue #34)。
+ */
+function removeDuplicateUrlFromOtherKeys(
+	storage: Record<string, readonly ClaudeSession[]>,
+	sessionUrl: string,
+	currentKey: string,
+): Record<string, readonly ClaudeSession[]> {
+	let result = storage;
+	for (const [key, sessions] of Object.entries(result)) {
+		if (key === currentKey) continue;
+		const filtered = sessions.filter((s) => s.sessionUrl !== sessionUrl);
+		if (filtered.length !== sessions.length) {
+			result = { ...result, [key]: filtered };
+		}
+	}
+	return result;
+}
+
+/**
  * Claude Code Web のセッションタイトルから Issue 番号を抽出する。
  *
  * パターン:
@@ -198,6 +218,8 @@ export class ClaudeSessionWatcher {
 
 		for (const session of validSessions) {
 			const key = String(session.issueNumber);
+			// セッションタイトル変更で Issue 番号が変わった場合、旧 key から同一 URL を削除する
+			merged = removeDuplicateUrlFromOtherKeys(merged, session.sessionUrl, key);
 			const existing = merged[key] ?? [];
 			const idx = existing.findIndex((s) => s.sessionUrl === session.sessionUrl);
 			const updatedSessions =
@@ -212,7 +234,9 @@ export class ClaudeSessionWatcher {
 	private async saveSession(session: ClaudeSession): Promise<void> {
 		const storage = await this.getSessions();
 		const key = String(session.issueNumber);
-		const existing = storage[key] ?? [];
+		// セッションタイトル変更で Issue 番号が変わった場合、旧 key から同一 URL を削除する
+		const cleaned = removeDuplicateUrlFromOtherKeys(storage, session.sessionUrl, key);
+		const existing = cleaned[key] ?? [];
 
 		// 同じ URL のセッションは更新、なければ追加
 		const idx = existing.findIndex((s) => s.sessionUrl === session.sessionUrl);
@@ -220,7 +244,7 @@ export class ClaudeSessionWatcher {
 			idx >= 0 ? existing.map((s, i) => (i === idx ? session : s)) : [...existing, session];
 
 		await chrome.storage.local.set({
-			[STORAGE_KEY]: { ...storage, [key]: updatedSessions },
+			[STORAGE_KEY]: { ...cleaned, [key]: updatedSessions },
 		});
 		if (import.meta.env.DEV) {
 			console.log(

--- a/src/sidepanel/components/TreeNode.svelte
+++ b/src/sidepanel/components/TreeNode.svelte
@@ -179,7 +179,7 @@
 
 	{#if open && hasChildren}
 		<div class="children">
-			{#each node.children as child (child.kind.type === "epic" ? `epic-${child.kind.number}` : child.kind.type === "issue" ? `issue-${child.kind.number}` : child.kind.type === "pullRequest" ? `pr-${child.kind.number}` : `session-${child.kind.url}`)}
+			{#each node.children as child (child.kind.type === "epic" ? `epic-${child.kind.number}` : child.kind.type === "issue" ? `issue-${child.kind.number}` : child.kind.type === "pullRequest" ? `pr-${child.kind.number}` : `session-${child.kind.issueNumber}-${child.kind.url}`)}
 				<TreeNode node={child} {activeTabUrl} {activeWorkspaceIssueNumber} parentIsActiveWorkspace={isWorkspaceActive} {onNavigate} {onOpenWorkspace} {onPin} />
 			{/each}
 		</div>

--- a/src/sidepanel/usecase/merge-sessions.ts
+++ b/src/sidepanel/usecase/merge-sessions.ts
@@ -17,6 +17,33 @@ function deduplicateSessionsByTitle(sessions: readonly ClaudeSession[]): readonl
 }
 
 /**
+ * 同一 sessionUrl が複数 Issue にまたがる場合、最新の detectedAt を持つ方のみ残す。
+ * Storage 層で防ぐのが本筋だが、既存データへの防御として merge 時にも除去する (Issue #34)。
+ */
+function deduplicateSessionsAcrossIssues(sessions: ClaudeSessionStorage): ClaudeSessionStorage {
+	// URL → { key, detectedAt } の最新エントリを収集
+	const latestByUrl = new Map<string, { key: string; detectedAt: string }>();
+	for (const [key, list] of Object.entries(sessions)) {
+		for (const s of list) {
+			const existing = latestByUrl.get(s.sessionUrl);
+			if (!existing || s.detectedAt > existing.detectedAt) {
+				latestByUrl.set(s.sessionUrl, { key, detectedAt: s.detectedAt });
+			}
+		}
+	}
+
+	// 最新でない key からは該当 URL を除去
+	const result: Record<string, readonly ClaudeSession[]> = {};
+	for (const [key, list] of Object.entries(sessions)) {
+		result[key] = list.filter((s) => {
+			const latest = latestByUrl.get(s.sessionUrl);
+			return latest !== undefined && latest.key === key;
+		});
+	}
+	return result;
+}
+
+/**
  * セッション情報をエピックツリーにマージする。
  * Issue ノードの子として、対応するセッションノードを追加する。
  * 純粋関数: 元のツリーは変更しない。
@@ -25,8 +52,9 @@ export function mergeSessionsIntoTree(
 	tree: EpicTreeDto,
 	sessions: ClaudeSessionStorage,
 ): EpicTreeDto {
+	const cleaned = deduplicateSessionsAcrossIssues(sessions);
 	return {
-		roots: tree.roots.map((root) => mergeSessionsIntoNode(root, sessions)),
+		roots: tree.roots.map((root) => mergeSessionsIntoNode(root, cleaned)),
 	};
 }
 

--- a/src/test/background/claude-session-watcher.test.ts
+++ b/src/test/background/claude-session-watcher.test.ts
@@ -418,6 +418,164 @@ describe("ClaudeSessionWatcher", () => {
 		});
 	});
 
+	// Issue #34: 同一 sessionUrl が別 Issue key に存在する場合、古い方を削除する
+	describe("Issue #34 — cross-issue sessionUrl 重複排除", () => {
+		it("saveSession: セッションタイトル変更で Issue 番号が変わった場合、旧 key から削除される", async () => {
+			// 既存: session_X が Issue #1592 に紐付いている
+			chromeMock.storage.local.get.mockResolvedValue({
+				claudeSessions: {
+					"1592": [
+						{
+							sessionUrl: "https://claude.ai/code/session_012Ke5HvnrbFoCD8bNmAtZV4",
+							title: "[close]Inv #1592 -> #2108",
+							issueNumber: 1592,
+							detectedAt: "2026-04-01T00:00:00Z",
+							isLive: true,
+						},
+					],
+				},
+			});
+
+			watcher.startWatching();
+			const onUpdatedCallback = chromeMock.tabs.onUpdated.addListener.mock.calls[0][0];
+
+			// 同じ sessionUrl だがタイトルが変わり Issue #2571 として検出される
+			await onUpdatedCallback(
+				1,
+				{ title: "Investigate issue 2571 | Claude Code" },
+				{
+					url: "https://claude.ai/code/session_012Ke5HvnrbFoCD8bNmAtZV4",
+					title: "Investigate issue 2571 | Claude Code",
+				},
+			);
+
+			await vi.waitFor(() => {
+				expect(chromeMock.storage.local.set).toHaveBeenCalled();
+			});
+
+			const setCall = chromeMock.storage.local.set.mock.calls[0][0];
+			// 新しい Issue key に保存されている
+			expect(setCall.claudeSessions["2571"]).toHaveLength(1);
+			expect(setCall.claudeSessions["2571"][0].sessionUrl).toBe(
+				"https://claude.ai/code/session_012Ke5HvnrbFoCD8bNmAtZV4",
+			);
+			// 旧 Issue key から削除されている
+			expect(setCall.claudeSessions["1592"]).toHaveLength(0);
+		});
+
+		it("saveSession: 旧 key に他セッションがある場合、該当 URL のみ削除される", async () => {
+			chromeMock.storage.local.get.mockResolvedValue({
+				claudeSessions: {
+					"1592": [
+						{
+							sessionUrl: "https://claude.ai/code/session_DUPLICATE",
+							title: "[close]Inv #1592",
+							issueNumber: 1592,
+							detectedAt: "2026-04-01T00:00:00Z",
+							isLive: true,
+						},
+						{
+							sessionUrl: "https://claude.ai/code/session_OTHER",
+							title: "Inv #1592 別セッション",
+							issueNumber: 1592,
+							detectedAt: "2026-04-02T00:00:00Z",
+							isLive: false,
+						},
+					],
+				},
+			});
+
+			watcher.startWatching();
+			const onUpdatedCallback = chromeMock.tabs.onUpdated.addListener.mock.calls[0][0];
+
+			await onUpdatedCallback(
+				1,
+				{ title: "Investigate issue 2571 | Claude Code" },
+				{
+					url: "https://claude.ai/code/session_DUPLICATE",
+					title: "Investigate issue 2571 | Claude Code",
+				},
+			);
+
+			await vi.waitFor(() => {
+				expect(chromeMock.storage.local.set).toHaveBeenCalled();
+			});
+
+			const setCall = chromeMock.storage.local.set.mock.calls[0][0];
+			// 新 key に移動
+			expect(setCall.claudeSessions["2571"]).toHaveLength(1);
+			// 旧 key には別セッションだけ残る
+			expect(setCall.claudeSessions["1592"]).toHaveLength(1);
+			expect(setCall.claudeSessions["1592"][0].sessionUrl).toBe(
+				"https://claude.ai/code/session_OTHER",
+			);
+		});
+
+		it("handleContentScriptSessions: 同一 URL が別 Issue に移動する場合、旧 key から削除される", async () => {
+			chromeMock.storage.local.get.mockResolvedValue({
+				claudeSessions: {
+					"1592": [
+						{
+							sessionUrl: "https://claude.ai/code/session_CROSS",
+							title: "Inv #1592",
+							issueNumber: 1592,
+							detectedAt: "2026-04-01T00:00:00Z",
+							isLive: false,
+						},
+					],
+				},
+			});
+
+			await watcher.handleContentScriptSessions([
+				{
+					url: "https://claude.ai/code/session_CROSS",
+					title: "Investigate issue 2571",
+				},
+			]);
+
+			const setCall = chromeMock.storage.local.set.mock.calls[0][0];
+			expect(setCall.claudeSessions["2571"]).toHaveLength(1);
+			expect(setCall.claudeSessions["1592"]).toHaveLength(0);
+		});
+
+		it("saveSession: 同一 key 内での URL 重複は従来通り更新される (cross-issue ではない)", async () => {
+			chromeMock.storage.local.get.mockResolvedValue({
+				claudeSessions: {
+					"2571": [
+						{
+							sessionUrl: "https://claude.ai/code/session_SAME",
+							title: "Investigate issue 2571 (old)",
+							issueNumber: 2571,
+							detectedAt: "2026-04-01T00:00:00Z",
+							isLive: false,
+						},
+					],
+				},
+			});
+
+			watcher.startWatching();
+			const onUpdatedCallback = chromeMock.tabs.onUpdated.addListener.mock.calls[0][0];
+
+			await onUpdatedCallback(
+				1,
+				{ title: "Investigate issue 2571 | Claude Code" },
+				{
+					url: "https://claude.ai/code/session_SAME",
+					title: "Investigate issue 2571 | Claude Code",
+				},
+			);
+
+			await vi.waitFor(() => {
+				expect(chromeMock.storage.local.set).toHaveBeenCalled();
+			});
+
+			const setCall = chromeMock.storage.local.set.mock.calls[0][0];
+			// 同一 key 内で更新、1件のまま
+			expect(setCall.claudeSessions["2571"]).toHaveLength(1);
+			expect(setCall.claudeSessions["2571"][0].title).toBe("Investigate issue 2571 | Claude Code");
+		});
+	});
+
 	// Issue #27: ストレージ更新後に Side Panel へ broadcast しないと、後から検知された
 	// セッションが UI に反映されない (Side Panel は購読しても通知が来ないため再取得しない)
 	describe("Issue #27 — Side Panel への broadcast", () => {

--- a/src/test/sidepanel/usecase/merge-sessions.test.ts
+++ b/src/test/sidepanel/usecase/merge-sessions.test.ts
@@ -336,6 +336,96 @@ describe("mergeSessionsIntoTree", () => {
 		expect(issueNode.children).toHaveLength(2);
 	});
 
+	// Issue #34: 同一 sessionUrl が複数 Issue にまたがる場合の防御的重複排除
+	it("同一 sessionUrl が複数 Issue に存在する場合、最新の detectedAt のみ残る", () => {
+		const tree: EpicTreeDto = {
+			roots: [makeEpicNode(1, [makeIssueNode(10), makeIssueNode(20)])],
+		};
+		const sessions: ClaudeSessionStorage = {
+			"10": [
+				{
+					sessionUrl: "https://claude.ai/code/session_CROSS",
+					title: "Inv #10 old title",
+					issueNumber: 10,
+					detectedAt: "2026-04-01T00:00:00Z",
+					isLive: false,
+				},
+			],
+			"20": [
+				{
+					sessionUrl: "https://claude.ai/code/session_CROSS",
+					title: "Investigate issue 20",
+					issueNumber: 20,
+					detectedAt: "2026-04-05T00:00:00Z",
+					isLive: true,
+				},
+			],
+		};
+
+		const result = mergeSessionsIntoTree(tree, sessions);
+
+		const issue10 = result.roots[0].children[0];
+		const issue20 = result.roots[0].children[1];
+		// Issue #10 からは除去、Issue #20 にのみ残る
+		expect(issue10.children).toHaveLength(0);
+		expect(issue20.children).toHaveLength(1);
+		if (issue20.children[0].kind.type === "session") {
+			expect(issue20.children[0].kind.url).toBe("https://claude.ai/code/session_CROSS");
+		}
+	});
+
+	it("cross-issue 重複排除で、重複していない URL は影響を受けない", () => {
+		const tree: EpicTreeDto = {
+			roots: [makeEpicNode(1, [makeIssueNode(10), makeIssueNode(20)])],
+		};
+		const sessions: ClaudeSessionStorage = {
+			"10": [
+				{
+					sessionUrl: "https://claude.ai/code/session_CROSS",
+					title: "Inv #10",
+					issueNumber: 10,
+					detectedAt: "2026-04-01T00:00:00Z",
+					isLive: false,
+				},
+				{
+					sessionUrl: "https://claude.ai/code/session_UNIQUE_A",
+					title: "Inv #10 other",
+					issueNumber: 10,
+					detectedAt: "2026-04-02T00:00:00Z",
+					isLive: false,
+				},
+			],
+			"20": [
+				{
+					sessionUrl: "https://claude.ai/code/session_CROSS",
+					title: "Investigate issue 20",
+					issueNumber: 20,
+					detectedAt: "2026-04-05T00:00:00Z",
+					isLive: true,
+				},
+				{
+					sessionUrl: "https://claude.ai/code/session_UNIQUE_B",
+					title: "Investigate issue 20 v2",
+					issueNumber: 20,
+					detectedAt: "2026-04-06T00:00:00Z",
+					isLive: true,
+				},
+			],
+		};
+
+		const result = mergeSessionsIntoTree(tree, sessions);
+
+		const issue10 = result.roots[0].children[0];
+		const issue20 = result.roots[0].children[1];
+		// Issue #10: CROSS は除去、UNIQUE_A は残る
+		expect(issue10.children).toHaveLength(1);
+		if (issue10.children[0].kind.type === "session") {
+			expect(issue10.children[0].kind.url).toBe("https://claude.ai/code/session_UNIQUE_A");
+		}
+		// Issue #20: CROSS と UNIQUE_B の両方残る
+		expect(issue20.children).toHaveLength(2);
+	});
+
 	it("returns tree with empty roots unchanged", () => {
 		const tree: EpicTreeDto = { roots: [] };
 		const sessions: ClaudeSessionStorage = {


### PR DESCRIPTION
## 概要

セッションタイトル変更で Issue 番号が変わると同一 `sessionUrl` が複数 Issue key に保存され、Svelte の `{#each}` で `each_key_duplicate` エラーが発生していた。3層で防御する修正。

## 変更内容

- `src/background/claude-session-watcher.ts`: `removeDuplicateUrlFromOtherKeys()` を追加。`saveSession` / `handleContentScriptSessions` で旧 Issue key から同一 URL を削除
- `src/sidepanel/usecase/merge-sessions.ts`: `deduplicateSessionsAcrossIssues()` を追加。既存データの cross-issue 重複を防御的に除去
- `src/sidepanel/components/TreeNode.svelte`: `{#each}` key を `session-${issueNumber}-${url}` の複合キーに変更
- `.npmrc`: `node-linker=hoisted` で Node.js v24 + pnpm の symlink 解決問題を回避

## 関連 Issue

closes #34

## テスト

- [x] `pnpm test` — watcher テスト 4件追加、merge-sessions テスト 2件追加、全 PASS
- [x] `pnpm build` — ビルド成功
- [x] `svelte-check` — 型チェック PASS
- [ ] Chrome 拡張ロードして DevTools Console に `each_key_duplicate` が出ないことを確認
- [ ] 同一セッションのタイトル変更シナリオで旧 Issue key から消えることを確認

## レビュー観点

- `removeDuplicateUrlFromOtherKeys` の全 key 走査が storage サイズに対してパフォーマンス的に問題ないか（通常数十件なので問題ないはず）
- `deduplicateSessionsAcrossIssues` の `detectedAt` 比較で最新を正しく選べているか