### PR TITLE
feat: Side Panel ヘッダに Issue 番号検索 & スクロールフォーカス機能を追加

### DIFF
--- a/src/sidepanel/components/IssueSearchBox.svelte
+++ b/src/sidepanel/components/IssueSearchBox.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	type Props = {
+		onSearch: (issueNumber: number) => void;
+		notFoundMessage?: string | null;
+	};
+
+	const { onSearch, notFoundMessage }: Props = $props();
+
+	let inputValue = $state("");
+
+	function handleSubmit(event: Event): void {
+		event.preventDefault();
+		const trimmed = inputValue.trim();
+		if (trimmed === "") return;
+		const num = Number.parseInt(trimmed, 10);
+		if (!Number.isFinite(num) || num <= 0) return;
+		onSearch(num);
+	}
+</script>
+
+<form class="search-form" onsubmit={handleSubmit}>
+	<div class="search-row">
+		<span class="search-prefix">#</span>
+		<input
+			type="text"
+			inputmode="numeric"
+			pattern="[0-9]*"
+			class="search-input"
+			placeholder="Issue 番号"
+			bind:value={inputValue}
+			aria-label="Issue number to search"
+		/>
+		<button type="submit" class="search-btn" aria-label="Search">
+			<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+				<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+			</svg>
+		</button>
+	</div>
+	{#if notFoundMessage}
+		<p class="not-found" role="status">{notFoundMessage}</p>
+	{/if}
+</form>
+
+<style>
+	.search-form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.375rem 0;
+	}
+
+	.search-row {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-border-primary);
+		border-radius: 4px;
+		padding: 0.125rem 0.375rem;
+		transition: border-color 0.15s;
+	}
+
+	.search-row:focus-within {
+		border-color: var(--color-accent-primary);
+	}
+
+	.search-prefix {
+		color: var(--color-text-secondary);
+		font-size: 0.75rem;
+		flex-shrink: 0;
+	}
+
+	.search-input {
+		flex: 1 1 auto;
+		min-width: 0;
+		background: none;
+		border: none;
+		outline: none;
+		color: var(--color-text-primary);
+		font-size: 0.8125rem;
+		padding: 0.125rem 0;
+	}
+
+	.search-input::placeholder {
+		color: var(--color-text-secondary);
+	}
+
+	.search-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		padding: 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--color-text-secondary);
+		transition: color 0.15s;
+		flex-shrink: 0;
+	}
+
+	.search-btn:hover {
+		color: var(--color-accent-primary);
+	}
+
+	.not-found {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--color-badge-red);
+	}
+</style>

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from "svelte";
+	import { tick, untrack } from "svelte";
 	import type { EpicTreeDto } from "../../domain/ports/epic-processor.port";
 	import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 	import type { CachedPrData } from "../../shared/types/cache";
@@ -13,9 +13,11 @@
 	import { mergeSessionsIntoTree } from "../usecase/merge-sessions";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { filterTreeByPin } from "../usecase/filter-tree-by-pin";
+	import { findNodeInTree, nodeKeyFor } from "../usecase/find-node-in-tree";
 	import type { PinnedTabsStore } from "../stores/pinned-tabs.svelte";
 	import EpicSection from "./EpicSection.svelte";
 	import EpicTabBar from "./EpicTabBar.svelte";
+	import IssueSearchBox from "./IssueSearchBox.svelte";
 	import LogoutButton from "./LogoutButton.svelte";
 	import RelativeTime from "./RelativeTime.svelte";
 	import type { DebugState } from "../../shared/types/messages";
@@ -40,10 +42,75 @@
 	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
 
 	let showDebugPanel = $state(false);
+	let searchNotFoundMessage = $state<string | null>(null);
+	const SEARCH_HIT_ANIMATION_MS = 2500;
+	const SEARCH_NOT_FOUND_TIMEOUT_MS = 3000;
+	let searchNotFoundTimer: ReturnType<typeof setTimeout> | null = null;
+	let searchHitTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function handlePin(tab: { type: "epic" | "issue"; number: number; title: string }): void {
 		void pinnedTabsStore.pin(tab);
 	}
+
+	async function scrollAndFlash(nodeKey: string): Promise<void> {
+		// Pin タブ切替などで DOM が差し替わる可能性があるため、Svelte の更新を待つ
+		await tick();
+		const el = document.querySelector<HTMLElement>(`[data-node-key="${CSS.escape(nodeKey)}"]`);
+		if (!el) {
+			// findNodeInTree で存在確認済みでも親が折りたたまれていると DOM には無い。
+			// サイレントにせずユーザーに伝える。
+			showNotFound("該当ノードが現在表示されていません (親が折りたたまれている可能性)");
+			return;
+		}
+		el.scrollIntoView({ behavior: "smooth", block: "center" });
+		if (searchHitTimer) clearTimeout(searchHitTimer);
+		el.classList.remove("search-hit");
+		// Svelte の class バインディングではアニメーション再スタートが保証できないため、
+		// reflow を強制して同一要素に再度 .search-hit を付与し animation を再生する
+		void el.offsetWidth;
+		el.classList.add("search-hit");
+		searchHitTimer = setTimeout(() => {
+			el.classList.remove("search-hit");
+			searchHitTimer = null;
+		}, SEARCH_HIT_ANIMATION_MS);
+	}
+
+	function showNotFound(message: string): void {
+		searchNotFoundMessage = message;
+		if (searchNotFoundTimer) clearTimeout(searchNotFoundTimer);
+		searchNotFoundTimer = setTimeout(() => {
+			searchNotFoundMessage = null;
+			searchNotFoundTimer = null;
+		}, SEARCH_NOT_FOUND_TIMEOUT_MS);
+	}
+
+	function handleSearchIssue(issueNumber: number): void {
+		if (!epicData) {
+			showNotFound("ツリーがまだロードされていません");
+			return;
+		}
+		const node = findNodeInTree(epicData, issueNumber);
+		if (!node) {
+			showNotFound(`#${issueNumber} は現在のツリーに存在しません`);
+			return;
+		}
+		searchNotFoundMessage = null;
+
+		// Pin タブでフィルタされている場合、該当ノードが表示範囲外なら All タブに切り替える
+		const key = pinnedTabsStore.activeKey;
+		if (key && displayedTree && !findNodeInTree(displayedTree, issueNumber)) {
+			void pinnedTabsStore.activate(null);
+		}
+
+		void scrollAndFlash(nodeKeyFor(node.kind));
+	}
+
+	$effect(() => {
+		return () => {
+			if (searchNotFoundTimer) clearTimeout(searchNotFoundTimer);
+			if (searchHitTimer) clearTimeout(searchHitTimer);
+		};
+	});
 
 	// activeKey から PinnedTabRef を導出してツリーをフィルタする
 	const displayedTree = $derived.by(() => {
@@ -221,40 +288,43 @@
 
 <main>
 	<header>
-		<div class="header-left">
-			<h1>PR Sidebar</h1>
-			<button
-				class="reload-button"
-				class:spinning={loading}
-				onclick={loadPrs}
-				disabled={loading}
-				aria-label="Reload"
-			>
-				<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-					<path d="M8 3a5 5 0 0 0-4.546 2.914.5.5 0 1 1-.908-.428A6 6 0 1 1 2.25 9.665a.5.5 0 1 1 .958.286A5 5 0 1 0 8 3z"/>
-					<path d="M8 1.5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0V2a.5.5 0 0 1 .5-.5z"/>
-					<path d="M5.146 3.854a.5.5 0 0 1 0-.708l2.5-2.5a.5.5 0 0 1 .708.708l-2.5 2.5a.5.5 0 0 1-.708 0z"/>
-				</svg>
-			</button>
-		</div>
-		<div class="header-right">
-			{#if lastUpdatedAt}
-				<span class="last-updated"><RelativeTime dateStr={lastUpdatedAt} /></span>
-			{/if}
-			{#if getDebugState}
+		<div class="header-top">
+			<div class="header-left">
+				<h1>PR Sidebar</h1>
 				<button
-					class="debug-toggle"
-					class:active={showDebugPanel}
-					onclick={() => { showDebugPanel = !showDebugPanel; }}
-					aria-label="Toggle debug panel"
+					class="reload-button"
+					class:spinning={loading}
+					onclick={loadPrs}
+					disabled={loading}
+					aria-label="Reload"
 				>
-					<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-						<path d="M4.978.855a.5.5 0 1 0-.956.29l.41 1.352A4.985 4.985 0 0 0 3 6h10a4.985 4.985 0 0 0-1.432-3.503l.41-1.352a.5.5 0 1 0-.956-.29l-.291.956A4.978 4.978 0 0 0 8 1a4.979 4.979 0 0 0-2.731.811l-.29-.956zM13 6v1H8.5V3.556a4.024 4.024 0 0 1 2.231.811l.291-.956zM6 .278l.291.956A4.028 4.028 0 0 0 4.018 3.5L3 6v1h4.5V3.556A4.094 4.094 0 0 1 6 .278zM1 8.5A.5.5 0 0 1 1.5 8H6v4a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5H1.5a.5.5 0 0 1-.5-.5zm9.5-.5H15a.5.5 0 0 1 0 1h-1.5V12a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1V8.5z"/>
+					<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+						<path d="M8 3a5 5 0 0 0-4.546 2.914.5.5 0 1 1-.908-.428A6 6 0 1 1 2.25 9.665a.5.5 0 1 1 .958.286A5 5 0 1 0 8 3z"/>
+						<path d="M8 1.5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0V2a.5.5 0 0 1 .5-.5z"/>
+						<path d="M5.146 3.854a.5.5 0 0 1 0-.708l2.5-2.5a.5.5 0 0 1 .708.708l-2.5 2.5a.5.5 0 0 1-.708 0z"/>
 					</svg>
 				</button>
-			{/if}
-			<LogoutButton {onLogout} />
+			</div>
+			<div class="header-right">
+				{#if lastUpdatedAt}
+					<span class="last-updated"><RelativeTime dateStr={lastUpdatedAt} /></span>
+				{/if}
+				{#if getDebugState}
+					<button
+						class="debug-toggle"
+						class:active={showDebugPanel}
+						onclick={() => { showDebugPanel = !showDebugPanel; }}
+						aria-label="Toggle debug panel"
+					>
+						<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+							<path d="M4.978.855a.5.5 0 1 0-.956.29l.41 1.352A4.985 4.985 0 0 0 3 6h10a4.985 4.985 0 0 0-1.432-3.503l.41-1.352a.5.5 0 1 0-.956-.29l-.291.956A4.978 4.978 0 0 0 8 1a4.979 4.979 0 0 0-2.731.811l-.29-.956zM13 6v1H8.5V3.556a4.024 4.024 0 0 1 2.231.811l.291-.956zM6 .278l.291.956A4.028 4.028 0 0 0 4.018 3.5L3 6v1h4.5V3.556A4.094 4.094 0 0 1 6 .278zM1 8.5A.5.5 0 0 1 1.5 8H6v4a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5H1.5a.5.5 0 0 1-.5-.5zm9.5-.5H15a.5.5 0 0 1 0 1h-1.5V12a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1V8.5z"/>
+						</svg>
+					</button>
+				{/if}
+				<LogoutButton {onLogout} />
+			</div>
 		</div>
+		<IssueSearchBox onSearch={handleSearchIssue} notFoundMessage={searchNotFoundMessage} />
 	</header>
 
 	{#if loading && !data}
@@ -286,14 +356,20 @@
 <style>
 	header {
 		display: flex;
-		justify-content: space-between;
-		align-items: center;
+		flex-direction: column;
+		gap: 0.25rem;
 		padding: 0.5rem 0;
 		border-bottom: 1px solid var(--color-border-primary);
 		position: sticky;
 		top: 0;
 		background: var(--color-bg-primary);
 		z-index: 10;
+	}
+
+	.header-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
 	}
 
 	h1 {

--- a/src/sidepanel/components/TreeNode.svelte
+++ b/src/sidepanel/components/TreeNode.svelte
@@ -3,6 +3,7 @@
 	import { safeUrl } from "../../shared/utils/url";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { resolveWorkspaceResources } from "../../shared/utils/workspace-resources";
+	import { nodeKeyFor } from "../usecase/find-node-in-tree";
 	import TreeNode from "./TreeNode.svelte";
 
 	type Props = {
@@ -16,6 +17,8 @@
 	};
 
 	const { node, activeTabUrl, activeWorkspaceIssueNumber, parentIsActiveWorkspace = false, onNavigate, onOpenWorkspace, onPin }: Props = $props();
+
+	const dataNodeKey = $derived(nodeKeyFor(node.kind));
 
 	function handlePin(event: MouseEvent): void {
 		event.stopPropagation();
@@ -73,6 +76,7 @@
 	class="tree-node"
 	class:active={isActive}
 	class:workspace-active={isWorkspaceActive}
+	data-node-key={dataNodeKey}
 	style="padding-left: calc({displayDepth} * 1.2rem)"
 >
 	{#if node.kind.type === "epic"}
@@ -179,7 +183,7 @@
 
 	{#if open && hasChildren}
 		<div class="children">
-			{#each node.children as child (child.kind.type === "epic" ? `epic-${child.kind.number}` : child.kind.type === "issue" ? `issue-${child.kind.number}` : child.kind.type === "pullRequest" ? `pr-${child.kind.number}` : `session-${child.kind.issueNumber}-${child.kind.url}`)}
+			{#each node.children as child (nodeKeyFor(child.kind))}
 				<TreeNode node={child} {activeTabUrl} {activeWorkspaceIssueNumber} parentIsActiveWorkspace={isWorkspaceActive} {onNavigate} {onOpenWorkspace} {onPin} />
 			{/each}
 		</div>
@@ -199,6 +203,25 @@
 	.tree-node.workspace-active {
 		background: rgba(163, 113, 247, 0.15);
 		border-left: 3px solid #a371f7;
+	}
+
+	:global(.tree-node.search-hit) {
+		animation: search-hit-flash 2.5s ease-out forwards;
+	}
+
+	@keyframes search-hit-flash {
+		0% {
+			background: rgba(255, 210, 77, 0.45);
+			box-shadow: inset 3px 0 0 0 #ffd24d;
+		}
+		70% {
+			background: rgba(255, 210, 77, 0.45);
+			box-shadow: inset 3px 0 0 0 #ffd24d;
+		}
+		100% {
+			background: transparent;
+			box-shadow: inset 3px 0 0 0 transparent;
+		}
 	}
 
 	.node-header {

--- a/src/sidepanel/usecase/find-node-in-tree.ts
+++ b/src/sidepanel/usecase/find-node-in-tree.ts
@@ -1,0 +1,39 @@
+import type { EpicTreeDto, TreeNodeDto } from "../../domain/ports/epic-processor.port";
+
+/**
+ * ツリーから指定 Issue 番号に一致するノード (epic / issue / pullRequest) を DFS で検索する。
+ * session ノードは検索対象外 (issueNumber は親 Issue への参照であり Issue 本体ではないため)。
+ *
+ * 純粋関数: 入力ツリーは変更しない。該当なしは null を返す。
+ */
+export function findNodeInTree(tree: EpicTreeDto, issueNumber: number): TreeNodeDto | null {
+	return findInNodes(tree.roots, issueNumber);
+}
+
+function findInNodes(nodes: readonly TreeNodeDto[], num: number): TreeNodeDto | null {
+	for (const node of nodes) {
+		if (matches(node, num)) return node;
+		const child = findInNodes(node.children, num);
+		if (child) return child;
+	}
+	return null;
+}
+
+function matches(node: TreeNodeDto, num: number): boolean {
+	const kind = node.kind;
+	if (kind.type === "epic" || kind.type === "issue" || kind.type === "pullRequest") {
+		return kind.number === num;
+	}
+	return false;
+}
+
+/**
+ * ノードの種別と番号から DOM 上の data 属性として使うキーを生成する。
+ * TreeNode.svelte の #each キーと揃えて querySelector で特定可能にする。
+ */
+export function nodeKeyFor(kind: TreeNodeDto["kind"]): string {
+	if (kind.type === "epic") return `epic-${kind.number}`;
+	if (kind.type === "issue") return `issue-${kind.number}`;
+	if (kind.type === "pullRequest") return `pr-${kind.number}`;
+	return `session-${kind.issueNumber}-${kind.url}`;
+}

--- a/src/test/sidepanel/usecase/find-node-in-tree.test.ts
+++ b/src/test/sidepanel/usecase/find-node-in-tree.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import type { EpicTreeDto, TreeNodeDto } from "../../../domain/ports/epic-processor.port";
+import { findNodeInTree, nodeKeyFor } from "../../../sidepanel/usecase/find-node-in-tree";
+
+function epic(num: number, children: readonly TreeNodeDto[] = [], depth = 0): TreeNodeDto {
+	return { kind: { type: "epic", number: num, title: `Epic #${num}` }, children, depth };
+}
+
+function issue(num: number, children: readonly TreeNodeDto[] = [], depth = 1): TreeNodeDto {
+	return {
+		kind: {
+			type: "issue",
+			number: num,
+			title: `Issue #${num}`,
+			url: `https://github.com/owner/repo/issues/${num}`,
+			state: "OPEN",
+			labels: [],
+		},
+		children,
+		depth,
+	};
+}
+
+function pr(num: number, children: readonly TreeNodeDto[] = [], depth = 2): TreeNodeDto {
+	return {
+		kind: {
+			type: "pullRequest",
+			number: num,
+			title: `PR #${num}`,
+			url: `https://github.com/owner/repo/pull/${num}`,
+			prData: {
+				additions: 0,
+				deletions: 0,
+				ciStatus: "Passed",
+				approvalStatus: "Approved",
+				mergeableStatus: "Mergeable",
+				isDraft: false,
+				sizeLabel: "S",
+				unresolvedCommentCount: 0,
+			},
+		},
+		children,
+		depth,
+	};
+}
+
+describe("findNodeInTree", () => {
+	it("ルート直下の epic を番号で検索できる", () => {
+		const tree: EpicTreeDto = { roots: [epic(1), epic(2)] };
+		const result = findNodeInTree(tree, 2);
+		expect(result).not.toBeNull();
+		expect(result?.kind.type).toBe("epic");
+		if (result?.kind.type === "epic") expect(result.kind.number).toBe(2);
+	});
+
+	it("深い階層の issue を番号で検索できる", () => {
+		const tree: EpicTreeDto = {
+			roots: [epic(1, [epic(2, [issue(100, [issue(200, [], 3)], 2)], 1)])],
+		};
+		const result = findNodeInTree(tree, 200);
+		expect(result).not.toBeNull();
+		expect(result?.kind.type).toBe("issue");
+		if (result?.kind.type === "issue") expect(result.kind.number).toBe(200);
+	});
+
+	it("pull request も番号で検索できる", () => {
+		const tree: EpicTreeDto = {
+			roots: [epic(1, [issue(10, [pr(999)], 1)])],
+		};
+		const result = findNodeInTree(tree, 999);
+		expect(result).not.toBeNull();
+		expect(result?.kind.type).toBe("pullRequest");
+		if (result?.kind.type === "pullRequest") expect(result.kind.number).toBe(999);
+	});
+
+	it("見つからない場合は null を返す", () => {
+		const tree: EpicTreeDto = { roots: [epic(1, [issue(10)])] };
+		expect(findNodeInTree(tree, 999)).toBeNull();
+	});
+
+	it("空のツリーに対して null を返す", () => {
+		const tree: EpicTreeDto = { roots: [] };
+		expect(findNodeInTree(tree, 1)).toBeNull();
+	});
+
+	it("同じ番号の epic と issue がある場合、先に見つかった方（DFS 順）を返す", () => {
+		const tree: EpicTreeDto = {
+			roots: [epic(42, [issue(42)])],
+		};
+		const result = findNodeInTree(tree, 42);
+		expect(result?.kind.type).toBe("epic");
+	});
+
+	it("session ノードは検索対象外（issueNumber でマッチしない）", () => {
+		const sessionNode: TreeNodeDto = {
+			kind: {
+				type: "session",
+				title: "Claude session",
+				url: "https://claude.ai/code/session_abc",
+				issueNumber: 500,
+			},
+			children: [],
+			depth: 2,
+		};
+		const tree: EpicTreeDto = {
+			roots: [epic(1, [issue(10, [sessionNode], 1)])],
+		};
+		expect(findNodeInTree(tree, 500)).toBeNull();
+	});
+
+	it("元のツリーは変更しない（純粋関数）", () => {
+		const tree: EpicTreeDto = { roots: [epic(1, [issue(10)])] };
+		const snapshot = JSON.stringify(tree);
+		findNodeInTree(tree, 10);
+		expect(JSON.stringify(tree)).toBe(snapshot);
+	});
+});
+
+describe("nodeKeyFor", () => {
+	it("epic ノードのキーは epic-<number>", () => {
+		expect(nodeKeyFor({ type: "epic", number: 7, title: "Epic" })).toBe("epic-7");
+	});
+
+	it("issue ノードのキーは issue-<number>", () => {
+		expect(
+			nodeKeyFor({
+				type: "issue",
+				number: 88,
+				title: "Issue",
+				url: "https://example.com/88",
+				state: "OPEN",
+				labels: [],
+			}),
+		).toBe("issue-88");
+	});
+
+	it("pullRequest ノードのキーは pr-<number>", () => {
+		expect(
+			nodeKeyFor({
+				type: "pullRequest",
+				number: 42,
+				title: "PR",
+				url: "https://example.com/42",
+				prData: {
+					additions: 0,
+					deletions: 0,
+					ciStatus: "Passed",
+					approvalStatus: "Approved",
+					mergeableStatus: "Mergeable",
+					isDraft: false,
+					sizeLabel: "S",
+					unresolvedCommentCount: 0,
+				},
+			}),
+		).toBe("pr-42");
+	});
+
+	it("session ノードのキーは session-<issueNumber>-<url>", () => {
+		expect(
+			nodeKeyFor({
+				type: "session",
+				title: "S",
+				url: "https://claude.ai/code/session_abc",
+				issueNumber: 10,
+			}),
+		).toBe("session-10-https://claude.ai/code/session_abc");
+	});
+});


### PR DESCRIPTION
## 概要

Side Panel のヘッダ下部に Issue 番号検索ボックスを常時表示し、入力番号でツリー内の該当ノードへスクロール & 一時ハイライトする。

## 変更内容

- 新規: find-node-in-tree.ts — ツリー DFS 探索の純関数 + nodeKeyFor
- 新規: find-node-in-tree.test.ts — ユニットテスト 12 ケース
- 新規: IssueSearchBox.svelte — 常時表示の検索 UI
- 修正: MainScreen.svelte — 検索ハンドラ + scrollIntoView + 一時ハイライト + Pin タブ切替 + timer クリーンアップ
- 修正: TreeNode.svelte — data-node-key + search-hit アニメ + #each キーを nodeKeyFor に統一

## 関連 Issue

- closes #38

## テスト

- [x] TypeScript 型チェック通過 (pnpm check → 0 errors)
- [x] フロントエンドテスト通過 (48/48 PASS、新規 12 ケース)
- [x] Rust lint 通過 (変更なし)
- [x] Rust テスト通過 (変更なし)
- [ ] /verify (ユーザーによる実ブラウザ確認 AC-10 pending)

## レビュー観点

- nodeKeyFor の一元化で #each キーと data 属性の不整合を防止
- 折りたたみノードへの検索時は showNotFound でサイレントフォールバック回避
- await tick() で Pin タブ切替後の DOM 再生成待ち
- $effect teardown で timer クリーンアップ
- アニメ再トリガーは reflow で強制再生
