### PR TITLE
fix(watcher): "Epic N" 形式タイトルの Issue 番号抽出に対応

### DIFF
--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -32,6 +32,7 @@ function removeDuplicateUrlFromOtherKeys(
  * - "Investigate issue 2185" -> 2185
  * - "[close] issue 1966" -> 1966
  * - "Inv #2013 -> #2065 [#1671]..." -> 2013
+ * - "playwright codegenみたいなのEpic 2576" -> 2576 (Issue #40)
  */
 export function extractIssueNumberFromTitle(title: string): number | null {
 	// "#数字" パターン (例: "Inv #1882", "#2013 -> #2065")
@@ -44,6 +45,13 @@ export function extractIssueNumberFromTitle(title: string): number | null {
 	const issueMatch = /issue\s+(\d+)/i.exec(title);
 	if (issueMatch) {
 		return Number(issueMatch[1]);
+	}
+
+	// "epic 数字" パターン — 大文字小文字不問 (例: "...Epic 2576")
+	// `#` や `issue` キーワードを含まない Epic タイトルをカバーする (Issue #40)
+	const epicMatch = /epic\s+(\d+)/i.exec(title);
+	if (epicMatch) {
+		return Number(epicMatch[1]);
 	}
 
 	return null;

--- a/src/test/background/claude-session-watcher.test.ts
+++ b/src/test/background/claude-session-watcher.test.ts
@@ -46,6 +46,24 @@ describe("extractIssueNumberFromTitle", () => {
 	it("extracts from 'Inv #1882 fix tests | Claude Code'", () => {
 		expect(extractIssueNumberFromTitle("Inv #1882 fix tests | Claude Code")).toBe(1882);
 	});
+
+	// Issue #40: "Epic N" 形式のタイトル (# や 'issue' キーワードを含まない) にも対応する
+	it("extracts from 'playwright codegenみたいなのEpic 2576'", () => {
+		expect(extractIssueNumberFromTitle("playwright codegenみたいなのEpic 2576")).toBe(2576);
+	});
+
+	it("extracts from 'epic 42' (lowercase)", () => {
+		expect(extractIssueNumberFromTitle("epic 42")).toBe(42);
+	});
+
+	it("extracts from 'Epic 2576 | Claude Code' with suffix", () => {
+		expect(extractIssueNumberFromTitle("Epic 2576 | Claude Code")).toBe(2576);
+	});
+
+	// `#` パターンが Epic より優先されることを保証する (混在ケース)
+	it("prioritizes '#N' over 'Epic N' when both appear", () => {
+		expect(extractIssueNumberFromTitle("Inv #1000 Epic 2576")).toBe(1000);
+	});
 });
 
 describe("ClaudeSessionWatcher", () => {


### PR DESCRIPTION
## 概要
Claude Code Web のセッションタイトルが `# や issue` キーワードを含まず `Epic N` 形式で Issue 番号を持つ場合に、Sidebar に表示されない問題を修正する。

## 変更内容
- `src/background/claude-session-watcher.ts`: `extractIssueNumberFromTitle` に `epic\s+(\d+)` パターン (case insensitive) を追加。優先順位は `#` → `issue` → `epic`
- `src/test/background/claude-session-watcher.test.ts`: `Epic N` / `epic N` / サフィックス付き / `#` 優先の 4 ケースを追加

## 関連 Issue
- closes #40

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check` — 0 errors、警告は既存のもので本 PR と無関係)
- [x] フロントエンドテスト通過 (`pnpm exec vitest run src/test/background/claude-session-watcher.test.ts` → 38/38 PASS)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なしのためスキップ
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なしのためスキップ
- [ ] `/verify` で検証ループ PASS — 本 PR は regex 1 パターン追加のみのため軽量検証で済ませている

### 手動確認
- `"playwright codegenみたいなのEpic 2576"` → `2576` ✅
- `"epic 42"` → `42` ✅
- `"Epic 2576 | Claude Code"` → `2576` ✅
- `"Inv #1000 Epic 2576"` → `1000` (`#` が優先) ✅

## レビュー観点
- 正規表現の優先順位 `#` → `issue` → `epic` が妥当か
- `Epic N` 形式をサポートすることで誤検出（"...Epic 42 of 100..." のようなケース）を招かないか
- 追加テストケースが十分か (他に想定すべきタイトル形式があれば指摘希望)