### PR TITLE
fix(watcher): 末尾数字フォールバックでキーワードなしタイトルを救済

### DIFF
--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -54,6 +54,21 @@ export function extractIssueNumberFromTitle(title: string): number | null {
 		return Number(epicMatch[1]);
 	}
 
+	// 末尾数字フォールバック — キーワードなしタイトル (例: "Context Rot対策 2598") を救済する (Issue #42)
+	// 語境界あり・3桁以上・末尾限定で誤検出を最小化。" | Claude Code" サフィックスは許容。
+	// フォールバック発動は logDebug で追跡可能にする (誤検出デバッグ用)。
+	const trailingMatch = /(?:^|\s)(\d{3,})(?:\s*\|.*)?$/.exec(title);
+	if (trailingMatch) {
+		const issueNumber = Number(trailingMatch[1]);
+		logDebug(
+			"info",
+			"watcher",
+			"extractIssueNumberFromTitle matched via trailing-digit fallback",
+			`title="${title}" → ${issueNumber}`,
+		).catch(() => {});
+		return issueNumber;
+	}
+
 	return null;
 }
 

--- a/src/test/background/claude-session-watcher.test.ts
+++ b/src/test/background/claude-session-watcher.test.ts
@@ -64,6 +64,38 @@ describe("extractIssueNumberFromTitle", () => {
 	it("prioritizes '#N' over 'Epic N' when both appear", () => {
 		expect(extractIssueNumberFromTitle("Inv #1000 Epic 2576")).toBe(1000);
 	});
+
+	// Issue #42: キーワードなし末尾数字フォールバック
+	it("extracts from 'Context Rot対策 2598' (trailing digit, no keyword)", () => {
+		expect(extractIssueNumberFromTitle("Context Rot対策 2598")).toBe(2598);
+	});
+
+	it("extracts from 'Context Rot対策 2598 | Claude Code' (with suffix)", () => {
+		expect(extractIssueNumberFromTitle("Context Rot対策 2598 | Claude Code")).toBe(2598);
+	});
+
+	it("returns null for '2026 roadmap' (digit is not trailing)", () => {
+		expect(extractIssueNumberFromTitle("2026 roadmap")).toBeNull();
+	});
+
+	it("returns null for 'Plan for 2026 migration' (trailing is word)", () => {
+		expect(extractIssueNumberFromTitle("Plan for 2026 migration")).toBeNull();
+	});
+
+	// 語境界: "V2598" のように文字列内の数字は末尾フォールバックで拾わない
+	it("returns null for 'V2598' (no word boundary before digits)", () => {
+		expect(extractIssueNumberFromTitle("V2598")).toBeNull();
+	});
+
+	// 2桁以下はフォールバック対象外 (既存 issue/epic パターンで拾われる範囲と衝突回避)
+	it("returns null for 'some title 42' (2 digits below threshold)", () => {
+		expect(extractIssueNumberFromTitle("some title 42")).toBeNull();
+	});
+
+	// 優先順確認: 末尾数字より # が優先
+	it("prioritizes '#N' over trailing digit fallback", () => {
+		expect(extractIssueNumberFromTitle("something #100 context 2598")).toBe(100);
+	});
 });
 
 describe("ClaudeSessionWatcher", () => {


### PR DESCRIPTION
## 概要
Claude Code Web のセッションタイトルに \`#\` / \`issue\` / \`epic\` のいずれも含まず末尾に Issue 番号らしき数字だけが付いているケース (例: \`\"Context Rot対策 2598\"\`) を救済する。既存3パターンのいずれにもマッチしなかった場合のみフォールバックで末尾数字を拾う。

## 変更内容
- \`src/background/claude-session-watcher.ts\`: \`extractIssueNumberFromTitle\` に末尾数字フォールバック正規表現 \`/(?:^|\s)(\d{3,})(?:\s*\|.*)?$/\` を追加。優先順は \`#\` → \`issue\` → \`epic\` → 末尾数字。発動時は \`logDebug\` で追跡可能
- \`src/test/background/claude-session-watcher.test.ts\`: 7 ケース追加 (ヒット 2 / 除外 4 / 優先順 1)

## 関連 Issue
- closes #42
- refs #40 (前回の Epic パターン対応)
- refs #43 (本 PR では regex 拡張で逃げるが、本質解決は Epic #43 の手動マッピング機能で進める)

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check` — 0 errors)
- [x] フロントエンドテスト通過 (claude-session-watcher.test.ts 45/45 PASS)
- [ ] Rust lint 通過 — Rust 変更なしのためスキップ
- [ ] Rust テスト通過 — Rust 変更なしのためスキップ
- [ ] \`/verify\` で検証ループ PASS — regex 追加のみの軽量変更のため省略

### 手動確認想定
- \`\"Context Rot対策 2598\"\` → \`2598\` ✅
- \`\"Context Rot対策 2598 | Claude Code\"\` → \`2598\` ✅
- \`\"2026 roadmap\"\` → \`null\` ✅ (末尾が数字でない)
- \`\"V2598\"\` → \`null\` ✅ (語境界なし)
- \`\"some title 42\"\` → \`null\` ✅ (3桁未満)

## レビュー観点
- 正規表現の誤検出リスク (末尾に偶然3桁数字があるタイトル) の許容範囲
- フォールバック発動 \`logDebug\` のノイズ量が適切か
- 本 PR は "regex 拡張で延命する" スタンス。本質解決は Epic #43 側で進める方針

## スクリーンショット
該当なし (UI 変更なし)