### PR TITLE
claude/investigate-issue-45-nnzNa

### DIFF
--- a/src/content/claude-session-scraper.ts
+++ b/src/content/claude-session-scraper.ts
@@ -8,13 +8,12 @@
  */
 
 import { logDebug } from "../shared/utils/debug-logger";
+import { SESSION_ID_PATTERN } from "../shared/utils/session-id";
 
 const SESSION_CONTAINER_SELECTOR = "div.cursor-pointer";
 const FIBER_KEY_PREFIX = "__reactFiber$";
 const MAX_FIBER_DEPTH = 10;
 const CLAUDE_CODE_BASE_URL = "https://claude.ai/code/";
-/** session.id は session_ + 英数字/ハイフン/アンダースコアのみ許可 (path traversal / query 混入防止) */
-const SESSION_ID_PATTERN = /^session_[a-zA-Z0-9_-]{1,128}$/;
 
 interface SessionLink {
 	readonly url: string;

--- a/src/shared/types/claude-session.ts
+++ b/src/shared/types/claude-session.ts
@@ -9,3 +9,10 @@ export interface ClaudeSession {
 export type ClaudeSessionStorage = {
 	readonly [issueNumber: string]: readonly ClaudeSession[];
 };
+
+/**
+ * Claude セッションと Issue 番号の手動マッピング。
+ * regex タイトル抽出では拾えないセッションをユーザーが手動で紐付けるために使用する (Epic #43)。
+ * key: sessionId (SESSION_ID_PATTERN 準拠) / value: Issue 番号
+ */
+export type SessionIssueMapping = { readonly [sessionId: string]: number };

--- a/src/shared/utils/session-id.ts
+++ b/src/shared/utils/session-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Claude セッション ID の形式検証ユーティリティ。
+ *
+ * claude.ai/code のセッション ID は内部的に `session_` プレフィックスを持つが、
+ * 信頼できない経路 (scraper の React fiber 経由、UI の手入力) から取得されるため、
+ * ストレージ保存前とクリック遷移前に必ず検証する必要がある。
+ *
+ * suffix の最大長 (128) は claude.ai の ULID/UUID 表現 + 安全マージンから決定。
+ * path traversal (`../`)、クエリ混入 (`?`)、フラグメント (`#`) を弾く目的で
+ * 英数字・ハイフン・アンダースコアのみ許可する。
+ */
+export const SESSION_ID_PATTERN: RegExp = /^session_[a-zA-Z0-9_-]{1,128}$/;
+
+export function isValidSessionId(value: unknown): value is string {
+	return typeof value === "string" && SESSION_ID_PATTERN.test(value);
+}

--- a/src/shared/utils/session-mapping-store.ts
+++ b/src/shared/utils/session-mapping-store.ts
@@ -1,0 +1,88 @@
+/**
+ * Claude セッションと Issue 番号の手動マッピングを CRUD するストア。
+ *
+ * 保存先は `chrome.storage.local` の `sessionIssueMapping` キー。
+ * Service Worker (background) と Sidepanel の両方から呼ばれうるため shared/utils に配置する。
+ *
+ * 書き込みは `writeQueue` で直列化する。
+ * chrome.storage.local.set は atomic だが read-modify-write 全体は atomic ではないため、
+ * 並行実行すると古い値を読んで上書きする lost update が発生する。
+ * モジュールレベルの Promise chain で後続タスクを前のタスクに連結してこれを防ぐ。
+ */
+import type { SessionIssueMapping } from "../types/claude-session";
+import { isValidSessionId } from "./session-id";
+
+const STORAGE_KEY = "sessionIssueMapping";
+
+/**
+ * 書き込みを直列化するための Promise chain。
+ * 各 write 操作はこのチェーンの末尾に append される。
+ * エラーは個別 Promise に伝播させるが、キュー自体は止めないため
+ * 失敗時も `writeQueue` は解決済みにして後続をブロックしない。
+ */
+let writeQueue: Promise<void> = Promise.resolve();
+
+function enqueueWrite<T>(fn: () => Promise<T>): Promise<T> {
+	const next = writeQueue.then(fn);
+	// 次のタスクが前のタスクの失敗でスキップされないようにキューは常に解決状態に戻す。
+	writeQueue = next.then(
+		() => undefined,
+		() => undefined,
+	);
+	return next;
+}
+
+function assertValidSessionId(sessionId: string): void {
+	if (!isValidSessionId(sessionId)) {
+		throw new Error(`Invalid sessionId: ${String(sessionId)}`);
+	}
+}
+
+function assertValidIssueNumber(issueNumber: number): void {
+	// Number.isInteger は NaN / Infinity / 非整数 をすべて false にする。
+	// 追加で issueNumber <= 0 を弾いて 0 と負数を禁止する。
+	if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+		throw new Error(`Invalid issueNumber: ${String(issueNumber)}`);
+	}
+}
+
+async function readAll(): Promise<SessionIssueMapping> {
+	const result = await chrome.storage.local.get(STORAGE_KEY);
+	return (result[STORAGE_KEY] as SessionIssueMapping | undefined) ?? {};
+}
+
+export async function getMapping(sessionId: string): Promise<number | undefined> {
+	assertValidSessionId(sessionId);
+	const all = await readAll();
+	return all[sessionId];
+}
+
+export async function getAllMappings(): Promise<SessionIssueMapping> {
+	return readAll();
+}
+
+export async function setMapping(sessionId: string, issueNumber: number): Promise<void> {
+	// async 関数にすることで assertXxx の同期 throw が自動的に rejected Promise になる。
+	// 呼び出し側が await/.catch で受け取れる一貫したエラー伝播を保証する。
+	assertValidSessionId(sessionId);
+	assertValidIssueNumber(issueNumber);
+	return enqueueWrite(async () => {
+		const current = await readAll();
+		// 不変性を保つため spread で新オブジェクトを作る。
+		const updated: SessionIssueMapping = { ...current, [sessionId]: issueNumber };
+		await chrome.storage.local.set({ [STORAGE_KEY]: updated });
+	});
+}
+
+export async function deleteMapping(sessionId: string): Promise<void> {
+	assertValidSessionId(sessionId);
+	return enqueueWrite(async () => {
+		const current = await readAll();
+		if (!(sessionId in current)) {
+			// 冪等性: 未登録 sessionId を削除してもエラーにしない。
+			return;
+		}
+		const { [sessionId]: _removed, ...rest } = current;
+		await chrome.storage.local.set({ [STORAGE_KEY]: rest });
+	});
+}

--- a/src/test/shared/utils/session-id.test.ts
+++ b/src/test/shared/utils/session-id.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_ID_PATTERN, isValidSessionId } from "../../../shared/utils/session-id";
+
+describe("SESSION_ID_PATTERN", () => {
+	it("session_ + 英数字のみのIDにマッチする", () => {
+		expect(SESSION_ID_PATTERN.test("session_01T7hN9fW6KuKZxn52isYdyR")).toBe(true);
+	});
+
+	it("session_ + ハイフン入りのIDにマッチする", () => {
+		expect(SESSION_ID_PATTERN.test("session_09baa7d1-8aaf-4a38-8a2d-e56c3256a0c0")).toBe(true);
+	});
+
+	it("session_ + アンダースコア入りのIDにマッチする", () => {
+		expect(SESSION_ID_PATTERN.test("session_foo_bar_baz")).toBe(true);
+	});
+
+	it("prefix が異なるIDにはマッチしない", () => {
+		expect(SESSION_ID_PATTERN.test("draft_09baa7d1")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("session-01T7hN9fW6")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("Session_abc123")).toBe(false);
+	});
+
+	it("prefix なしの文字列にはマッチしない", () => {
+		expect(SESSION_ID_PATTERN.test("abc123")).toBe(false);
+	});
+
+	it("空文字列にはマッチしない", () => {
+		expect(SESSION_ID_PATTERN.test("")).toBe(false);
+	});
+
+	it("session_ だけ (suffix 空) にはマッチしない", () => {
+		expect(SESSION_ID_PATTERN.test("session_")).toBe(false);
+	});
+
+	it("特殊文字を含むIDにはマッチしない", () => {
+		expect(SESSION_ID_PATTERN.test("session_abc/../etc")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("session_abc?query=1")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("session_abc#frag")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("session_abc def")).toBe(false);
+		expect(SESSION_ID_PATTERN.test("session_abc\n")).toBe(false);
+	});
+
+	it("suffix が 128 文字を超える場合はマッチしない", () => {
+		const suffix129 = "a".repeat(129);
+		expect(SESSION_ID_PATTERN.test(`session_${suffix129}`)).toBe(false);
+	});
+
+	it("suffix が 128 文字ちょうどはマッチする (境界値)", () => {
+		const suffix128 = "a".repeat(128);
+		expect(SESSION_ID_PATTERN.test(`session_${suffix128}`)).toBe(true);
+	});
+});
+
+describe("isValidSessionId", () => {
+	it("有効な sessionId に対して true を返す", () => {
+		expect(isValidSessionId("session_01T7hN9fW6KuKZxn52isYdyR")).toBe(true);
+		expect(isValidSessionId("session_abc-def_123")).toBe(true);
+	});
+
+	it("無効な文字列に対して false を返す", () => {
+		expect(isValidSessionId("draft_09baa7d1")).toBe(false);
+		expect(isValidSessionId("")).toBe(false);
+		expect(isValidSessionId("not-a-session")).toBe(false);
+	});
+
+	it("文字列以外の値に対して false を返す (型ガード)", () => {
+		expect(isValidSessionId(null)).toBe(false);
+		expect(isValidSessionId(undefined)).toBe(false);
+		expect(isValidSessionId(123)).toBe(false);
+		expect(isValidSessionId({})).toBe(false);
+		expect(isValidSessionId([])).toBe(false);
+		expect(isValidSessionId(true)).toBe(false);
+	});
+
+	it("129 文字以上の suffix に対して false を返す", () => {
+		const suffix129 = "a".repeat(129);
+		expect(isValidSessionId(`session_${suffix129}`)).toBe(false);
+	});
+});

--- a/src/test/shared/utils/session-mapping-store.test.ts
+++ b/src/test/shared/utils/session-mapping-store.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	deleteMapping,
+	getAllMappings,
+	getMapping,
+	setMapping,
+} from "../../../shared/utils/session-mapping-store";
+import { resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+const STORAGE_KEY = "sessionIssueMapping";
+const VALID_SESSION_A = "session_01T7hN9fW6KuKZxn52isYdyR";
+const VALID_SESSION_B = "session_abc123def456";
+const VALID_SESSION_C = "session_xyz789";
+const INVALID_SESSION = "draft_09baa7d1";
+
+/**
+ * 内部ストレージを 1 つのオブジェクトで保持し、get/set/remove mock が
+ * 実ストレージのように振る舞うようにする。
+ * これによって race condition テスト(複数 setMapping 並行実行後に全エントリ残存)が
+ * 実質的に意味のある検証になる。
+ */
+function installInMemoryStorage(): { getState: () => Record<string, unknown> } {
+	const mock = setupChromeMock();
+	const state: Record<string, unknown> = {};
+
+	mock.storage.local.get.mockImplementation(async (key: string | string[] | null) => {
+		if (key === null || key === undefined) return { ...state };
+		const keys = Array.isArray(key) ? key : [key];
+		const result: Record<string, unknown> = {};
+		for (const k of keys) {
+			if (k in state) result[k] = state[k];
+		}
+		return result;
+	});
+
+	mock.storage.local.set.mockImplementation(async (items: Record<string, unknown>) => {
+		for (const [k, v] of Object.entries(items)) {
+			state[k] = v;
+		}
+	});
+
+	mock.storage.local.remove.mockImplementation(async (key: string | string[]) => {
+		const keys = Array.isArray(key) ? key : [key];
+		for (const k of keys) {
+			delete state[k];
+		}
+	});
+
+	return { getState: () => state };
+}
+
+describe("session-mapping-store", () => {
+	let storage: { getState: () => Record<string, unknown> };
+
+	beforeEach(() => {
+		storage = installInMemoryStorage();
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+	});
+
+	describe("getMapping", () => {
+		it("登録済 sessionId に対して issueNumber を返す", async () => {
+			storage.getState()[STORAGE_KEY] = { [VALID_SESSION_A]: 45 };
+			await expect(getMapping(VALID_SESSION_A)).resolves.toBe(45);
+		});
+
+		it("未登録 sessionId に対して undefined を返す", async () => {
+			storage.getState()[STORAGE_KEY] = { [VALID_SESSION_A]: 45 };
+			await expect(getMapping(VALID_SESSION_B)).resolves.toBeUndefined();
+		});
+
+		it("ストレージが空 ({}) のときに undefined を返す", async () => {
+			await expect(getMapping(VALID_SESSION_A)).resolves.toBeUndefined();
+		});
+
+		it("無効な sessionId に対して reject する", async () => {
+			await expect(getMapping(INVALID_SESSION)).rejects.toThrow(/Invalid sessionId/);
+		});
+	});
+
+	describe("setMapping", () => {
+		it("新規 sessionId をストレージに保存する", async () => {
+			await setMapping(VALID_SESSION_A, 45);
+			expect(storage.getState()[STORAGE_KEY]).toEqual({ [VALID_SESSION_A]: 45 });
+		});
+
+		it("既存 sessionId を上書きする", async () => {
+			await setMapping(VALID_SESSION_A, 45);
+			await setMapping(VALID_SESSION_A, 99);
+			expect(storage.getState()[STORAGE_KEY]).toEqual({ [VALID_SESSION_A]: 99 });
+		});
+
+		it("他の sessionId エントリに影響しない (不変性)", async () => {
+			await setMapping(VALID_SESSION_A, 1);
+			await setMapping(VALID_SESSION_B, 2);
+			expect(storage.getState()[STORAGE_KEY]).toEqual({
+				[VALID_SESSION_A]: 1,
+				[VALID_SESSION_B]: 2,
+			});
+		});
+
+		it("無効な sessionId に対して reject する", async () => {
+			await expect(setMapping(INVALID_SESSION, 45)).rejects.toThrow(/Invalid sessionId/);
+		});
+
+		it("無効な issueNumber (負数) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, -1)).rejects.toThrow(/Invalid issueNumber/);
+		});
+
+		it("無効な issueNumber (0) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, 0)).rejects.toThrow(/Invalid issueNumber/);
+		});
+
+		it("無効な issueNumber (非整数) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, 1.5)).rejects.toThrow(/Invalid issueNumber/);
+		});
+
+		it("無効な issueNumber (NaN) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, Number.NaN)).rejects.toThrow(/Invalid issueNumber/);
+		});
+
+		it("無効な issueNumber (Infinity) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, Number.POSITIVE_INFINITY)).rejects.toThrow(
+				/Invalid issueNumber/,
+			);
+		});
+
+		it("無効な issueNumber (-Infinity) に対して reject する", async () => {
+			await expect(setMapping(VALID_SESSION_A, Number.NEGATIVE_INFINITY)).rejects.toThrow(
+				/Invalid issueNumber/,
+			);
+		});
+
+		it("最小有効値 issueNumber=1 を受け付ける (境界値)", async () => {
+			await expect(setMapping(VALID_SESSION_A, 1)).resolves.toBeUndefined();
+			expect(storage.getState()[STORAGE_KEY]).toEqual({ [VALID_SESSION_A]: 1 });
+		});
+
+		it("大きな正の整数を受け付ける", async () => {
+			await expect(setMapping(VALID_SESSION_A, 999999)).resolves.toBeUndefined();
+			expect(storage.getState()[STORAGE_KEY]).toEqual({ [VALID_SESSION_A]: 999999 });
+		});
+	});
+
+	describe("deleteMapping", () => {
+		it("既存 sessionId をストレージから削除する", async () => {
+			await setMapping(VALID_SESSION_A, 45);
+			await deleteMapping(VALID_SESSION_A);
+			const current = (storage.getState()[STORAGE_KEY] as Record<string, number>) ?? {};
+			expect(current[VALID_SESSION_A]).toBeUndefined();
+		});
+
+		it("未登録 sessionId でも throw しない (冪等性)", async () => {
+			await expect(deleteMapping(VALID_SESSION_A)).resolves.toBeUndefined();
+		});
+
+		it("他の sessionId エントリに影響しない", async () => {
+			await setMapping(VALID_SESSION_A, 1);
+			await setMapping(VALID_SESSION_B, 2);
+			await deleteMapping(VALID_SESSION_A);
+			expect(storage.getState()[STORAGE_KEY]).toEqual({ [VALID_SESSION_B]: 2 });
+		});
+
+		it("無効な sessionId に対して reject する", async () => {
+			await expect(deleteMapping(INVALID_SESSION)).rejects.toThrow(/Invalid sessionId/);
+		});
+	});
+
+	describe("getAllMappings", () => {
+		it("全エントリを返す", async () => {
+			await setMapping(VALID_SESSION_A, 1);
+			await setMapping(VALID_SESSION_B, 2);
+			await expect(getAllMappings()).resolves.toEqual({
+				[VALID_SESSION_A]: 1,
+				[VALID_SESSION_B]: 2,
+			});
+		});
+
+		it("空ストレージでは {} を返す", async () => {
+			await expect(getAllMappings()).resolves.toEqual({});
+		});
+	});
+
+	describe("race condition", () => {
+		/**
+		 * 複数の setMapping を並行発火して、すべての書き込みが反映されることを検証する。
+		 * シリアライズしないと read-modify-write が互いを上書きして一部のエントリが失われる。
+		 */
+		it("3 つの setMapping を並行発火しても全エントリが残る", async () => {
+			await Promise.all([
+				setMapping(VALID_SESSION_A, 1),
+				setMapping(VALID_SESSION_B, 2),
+				setMapping(VALID_SESSION_C, 3),
+			]);
+
+			expect(storage.getState()[STORAGE_KEY]).toEqual({
+				[VALID_SESSION_A]: 1,
+				[VALID_SESSION_B]: 2,
+				[VALID_SESSION_C]: 3,
+			});
+		});
+
+		it("set と delete の並行発火でも整合性が保たれる", async () => {
+			await setMapping(VALID_SESSION_A, 1);
+
+			await Promise.all([
+				setMapping(VALID_SESSION_B, 2),
+				deleteMapping(VALID_SESSION_A),
+				setMapping(VALID_SESSION_C, 3),
+			]);
+
+			const current = (storage.getState()[STORAGE_KEY] as Record<string, number>) ?? {};
+			expect(current[VALID_SESSION_A]).toBeUndefined();
+			expect(current[VALID_SESSION_B]).toBe(2);
+			expect(current[VALID_SESSION_C]).toBe(3);
+		});
+
+		it("同一 sessionId への連続 setMapping では最後の値が残る", async () => {
+			await Promise.all([
+				setMapping(VALID_SESSION_A, 1),
+				setMapping(VALID_SESSION_A, 2),
+				setMapping(VALID_SESSION_A, 3),
+			]);
+
+			const current = storage.getState()[STORAGE_KEY] as Record<string, number>;
+			expect(current[VALID_SESSION_A]).toBe(3);
+		});
+	});
+});


### PR DESCRIPTION
Epic #43 Phase 1 の土台実装。
- SessionIssueMapping 型を追加
- chrome.storage.local に CRUD するストアを shared/utils に配置
  (Service Worker と Sidepanel 両方から利用されるため)
- race condition 対策: 書き込みを Promise chain でシリアライズ
- SESSION_ID_PATTERN を shared/utils/session-id.ts に切り出して共通化
- scraper の重複定義を削除

refs #45
refs #43