### PR TITLE
Add manual session-to-issue mapping support (Epic #43)

### DIFF
--- a/rust-core/crates/domain/src/epic.rs
+++ b/rust-core/crates/domain/src/epic.rs
@@ -32,7 +32,9 @@ pub enum TreeNodeKind {
         issue_number: u32,
         /// `true` のとき、ユーザーが手動で `SessionIssueMapping` 経由で配置した
         /// セッションであることを示す (Epic #43)。TS 側の TreeNodeDto とスキーマを一致させる。
-        #[serde(rename = "isManuallyMapped")]
+        /// `#[serde(default)]` により、このフィールドを含まない旧キャッシュ JSON を
+        /// 読んだ場合は `false` にフォールバックして後方互換を保つ。
+        #[serde(rename = "isManuallyMapped", default)]
         is_manually_mapped: bool,
     },
 }
@@ -241,5 +243,28 @@ mod tests {
             json.contains("\"issueNumber\""),
             "expected issueNumber in JSON, got: {json}"
         );
+    }
+
+    /// `isManuallyMapped` を含まない旧スキーマ JSON をデシリアライズしても、
+    /// `#[serde(default)]` により `false` フォールバックして後方互換を保つことを確認する。
+    #[test]
+    fn session_node_deserializes_legacy_json_without_is_manually_mapped() {
+        let legacy_json = r#"{
+            "kind": {
+                "type": "session",
+                "title": "legacy",
+                "url": "https://claude.ai/code/session_legacy",
+                "issueNumber": 42
+            },
+            "children": [],
+            "depth": 2
+        }"#;
+        let node: TreeNode = serde_json::from_str(legacy_json).expect("deserialize legacy JSON");
+        match node.kind {
+            TreeNodeKind::Session {
+                is_manually_mapped, ..
+            } => assert!(!is_manually_mapped),
+            other => panic!("expected Session variant, got {other:?}"),
+        }
     }
 }

--- a/rust-core/crates/domain/src/epic.rs
+++ b/rust-core/crates/domain/src/epic.rs
@@ -30,6 +30,10 @@ pub enum TreeNodeKind {
         url: String,
         #[serde(rename = "issueNumber")]
         issue_number: u32,
+        /// `true` のとき、ユーザーが手動で `SessionIssueMapping` 経由で配置した
+        /// セッションであることを示す (Epic #43)。TS 側の TreeNodeDto とスキーマを一致させる。
+        #[serde(rename = "isManuallyMapped")]
+        is_manually_mapped: bool,
     },
 }
 
@@ -227,6 +231,7 @@ mod tests {
                 title: "Inv #1882".to_string(),
                 url: "https://claude.ai/code/session_123".to_string(),
                 issue_number: 1882,
+                is_manually_mapped: false,
             },
             2,
         );

--- a/src/domain/ports/epic-processor.port.ts
+++ b/src/domain/ports/epic-processor.port.ts
@@ -36,6 +36,12 @@ export type TreeNodeKind =
 			readonly title: string;
 			readonly url: string;
 			readonly issueNumber: number;
+			/**
+			 * `true` のとき、この session ノードはユーザーが手動で Issue に紐付けた
+			 * `SessionIssueMapping` 経由で配置されていることを示す (Epic #43)。
+			 * regex 抽出のみで配置された場合は `false`。UI バッジ表示用。
+			 */
+			readonly isManuallyMapped: boolean;
 	  };
 
 export interface TreeNodeDto {

--- a/src/shared/utils/session-id.ts
+++ b/src/shared/utils/session-id.ts
@@ -15,10 +15,17 @@ export function isValidSessionId(value: unknown): value is string {
 	return typeof value === "string" && SESSION_ID_PATTERN.test(value);
 }
 
+/** claude.ai/code の正規オリジン。他ホストや javascript:/data: スキームを防御する。 */
+const CLAUDE_CODE_ORIGIN = "https://claude.ai";
+
 /**
  * claude.ai/code のセッション URL から sessionId を抽出する。
- * URL 末尾セグメントが `session_...` パターンに合致しない場合は null を返す。
- * クエリ・フラグメントは許容して落とす (SESSION_ID_PATTERN 自体は弾くため)。
+ * 以下のいずれかに該当する場合は null を返す。
+ * - URL として不正 (new URL が throw)
+ * - スキームが https でない、またはホストが claude.ai でない (フィッシング/XSS 防御)
+ * - 末尾セグメントが `SESSION_ID_PATTERN` に合致しない
+ *
+ * クエリ・フラグメントは URL オブジェクトが分離するため pathname 末尾の評価に影響しない。
  */
 export function extractSessionIdFromUrl(url: string): string | null {
 	let parsed: URL;
@@ -27,6 +34,7 @@ export function extractSessionIdFromUrl(url: string): string | null {
 	} catch {
 		return null;
 	}
+	if (parsed.origin !== CLAUDE_CODE_ORIGIN) return null;
 	const segments = parsed.pathname.split("/").filter((s) => s.length > 0);
 	const last = segments[segments.length - 1];
 	if (last === undefined) return null;

--- a/src/shared/utils/session-id.ts
+++ b/src/shared/utils/session-id.ts
@@ -14,3 +14,21 @@ export const SESSION_ID_PATTERN: RegExp = /^session_[a-zA-Z0-9_-]{1,128}$/;
 export function isValidSessionId(value: unknown): value is string {
 	return typeof value === "string" && SESSION_ID_PATTERN.test(value);
 }
+
+/**
+ * claude.ai/code のセッション URL から sessionId を抽出する。
+ * URL 末尾セグメントが `session_...` パターンに合致しない場合は null を返す。
+ * クエリ・フラグメントは許容して落とす (SESSION_ID_PATTERN 自体は弾くため)。
+ */
+export function extractSessionIdFromUrl(url: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	const segments = parsed.pathname.split("/").filter((s) => s.length > 0);
+	const last = segments[segments.length - 1];
+	if (last === undefined) return null;
+	return isValidSessionId(last) ? last : null;
+}

--- a/src/shared/utils/session-mapping-store.ts
+++ b/src/shared/utils/session-mapping-store.ts
@@ -46,9 +46,28 @@ function assertValidIssueNumber(issueNumber: number): void {
 	}
 }
 
+/**
+ * chrome.storage.local から読み出した任意値を `SessionIssueMapping` に正規化する。
+ * 外部拡張や devtools 経由でストレージが汚染された場合でも信頼せず、
+ * 値側 (非正整数) とキー側 (sessionId パターン違反) の不正エントリは除外する。
+ * 全体が object でない場合は {} を返す。
+ */
+function sanitizeMapping(raw: unknown): SessionIssueMapping {
+	if (raw === null || raw === undefined) return {};
+	if (typeof raw !== "object" || Array.isArray(raw)) return {};
+	const result: Record<string, number> = {};
+	for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+		if (!isValidSessionId(key)) continue;
+		if (typeof value !== "number") continue;
+		if (!Number.isInteger(value) || value <= 0) continue;
+		result[key] = value;
+	}
+	return result;
+}
+
 async function readAll(): Promise<SessionIssueMapping> {
 	const result = await chrome.storage.local.get(STORAGE_KEY);
-	return (result[STORAGE_KEY] as SessionIssueMapping | undefined) ?? {};
+	return sanitizeMapping(result[STORAGE_KEY]);
 }
 
 export async function getMapping(sessionId: string): Promise<number | undefined> {

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { untrack } from "svelte";
 	import type { EpicTreeDto } from "../domain/ports/epic-processor.port";
-	import type { ClaudeSessionStorage } from "../shared/types/claude-session";
+	import type { ClaudeSessionStorage, SessionIssueMapping } from "../shared/types/claude-session";
 	import LoginScreen from "./components/LoginScreen.svelte";
 	import MainScreen from "./components/MainScreen.svelte";
 	import type { createAuthUseCase } from "../shared/usecase/auth.usecase.js";
@@ -16,6 +16,7 @@
 		prUseCase: ReturnType<typeof createPrUseCase>;
 		fetchEpicTree: () => Promise<{ tree: EpicTreeDto; prsRawJson: string }>;
 		getClaudeSessions: () => Promise<ClaudeSessionStorage>;
+		getSessionIssueMappings: () => Promise<SessionIssueMapping>;
 		deviceFlowController: DeviceFlowController;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
 		pinnedTabsStore: PinnedTabsStore;
@@ -24,7 +25,7 @@
 		getCurrentTabUrl?: () => Promise<string | null>;
 		getDebugState?: () => Promise<DebugState>;
 	};
-	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, deviceFlowController, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, deviceFlowController, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
 
 	let authenticated = $state(false);
 	let loading = $state(true);
@@ -64,7 +65,7 @@
 		<p>Loading...</p>
 	</div>
 {:else if authenticated}
-	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} {getDebugState} />
+	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} {getSessionIssueMappings} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} {getDebugState} />
 {:else}
 	<LoginScreen controller={deviceFlowController} />
 {/if}

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -3,7 +3,7 @@
 	import type { EpicTreeDto } from "../../domain/ports/epic-processor.port";
 	import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 	import type { CachedPrData } from "../../shared/types/cache";
-	import type { ClaudeSessionStorage } from "../../shared/types/claude-session";
+	import type { ClaudeSessionStorage, SessionIssueMapping } from "../../shared/types/claude-session";
 	import {
 		isCacheUpdatedEvent,
 		isClaudeSessionsUpdatedEvent,
@@ -11,7 +11,6 @@
 	} from "../../shared/types/events";
 	import { extractPrIssueLinks, movePrsToLinkedIssues } from "../usecase/merge-prs-to-issues";
 	import { mergeSessionsIntoTree } from "../usecase/merge-sessions";
-	import { getAllMappings } from "../../shared/utils/session-mapping-store";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { filterTreeByPin } from "../usecase/filter-tree-by-pin";
 	import { findNodeInTree, nodeKeyFor } from "../usecase/find-node-in-tree";
@@ -30,6 +29,7 @@
 		fetchPrs: () => Promise<ProcessedPrsResult & { hasMore: boolean }>;
 		fetchEpicTree: () => Promise<{ tree: EpicTreeDto; prsRawJson: string }>;
 		getClaudeSessions: () => Promise<ClaudeSessionStorage>;
+		getSessionIssueMappings: () => Promise<SessionIssueMapping>;
 		getCachedPrs: () => Promise<CachedPrData | null>;
 		loadPrsWithCache: (minutes: number) => Promise<(ProcessedPrsResult & { hasMore: boolean }) | null>;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
@@ -40,7 +40,36 @@
 		getDebugState?: () => Promise<DebugState>;
 	};
 
-	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+
+	/**
+	 * sessions と mapping を並行取得する。
+	 * mapping 側が reject しても sessions だけでツリーを構築できるよう allSettled を使い、
+	 * 失敗時は空 mapping にフォールバックしつつ DEV ビルドで warn を残す。
+	 * `getClaudeSessions` が reject した場合は従来通り上位 catch で epicError を表示する。
+	 */
+	async function fetchSessionsAndMapping(): Promise<{
+		sessions: ClaudeSessionStorage;
+		mapping: SessionIssueMapping;
+	}> {
+		const [sessionsResult, mappingResult] = await Promise.allSettled([
+			getClaudeSessions(),
+			getSessionIssueMappings(),
+		]);
+		if (sessionsResult.status === "rejected") {
+			throw sessionsResult.reason;
+		}
+		if (mappingResult.status === "rejected") {
+			if (import.meta.env.DEV) {
+				console.warn(
+					"[MainScreen] getSessionIssueMappings failed; falling back to empty mapping:",
+					mappingResult.reason,
+				);
+			}
+			return { sessions: sessionsResult.value, mapping: {} };
+		}
+		return { sessions: sessionsResult.value, mapping: mappingResult.value };
+	}
 
 	let showDebugPanel = $state(false);
 	let searchNotFoundMessage = $state<string | null>(null);
@@ -154,7 +183,7 @@
 			const { tree, prsRawJson } = await fetchEpicTree();
 			const prLinks = extractPrIssueLinks(prsRawJson);
 			const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
-			const [sessions, mapping] = await Promise.all([getClaudeSessions(), getAllMappings()]);
+			const { sessions, mapping } = await fetchSessionsAndMapping();
 			epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
 			epicError = null;
 		} catch (e: unknown) {
@@ -216,7 +245,7 @@
 				const { tree, prsRawJson } = await fetchEpicTree();
 				const prLinks = extractPrIssueLinks(prsRawJson);
 				const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
-				const [sessions, mapping] = await Promise.all([getClaudeSessions(), getAllMappings()]);
+				const { sessions, mapping } = await fetchSessionsAndMapping();
 				if (!cancelled) {
 					epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
 				}
@@ -265,8 +294,8 @@
 				activeTabUrl = message.url;
 			}
 			if (isClaudeSessionsUpdatedEvent(message)) {
-				Promise.all([getClaudeSessions(), getAllMappings()])
-					.then(([sessions, mapping]) => {
+				fetchSessionsAndMapping()
+					.then(({ sessions, mapping }) => {
 						if (epicData) {
 							epicData = mergeSessionsIntoTree(epicData, sessions, mapping);
 						}

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -11,6 +11,7 @@
 	} from "../../shared/types/events";
 	import { extractPrIssueLinks, movePrsToLinkedIssues } from "../usecase/merge-prs-to-issues";
 	import { mergeSessionsIntoTree } from "../usecase/merge-sessions";
+	import { getAllMappings } from "../../shared/utils/session-mapping-store";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { filterTreeByPin } from "../usecase/filter-tree-by-pin";
 	import { findNodeInTree, nodeKeyFor } from "../usecase/find-node-in-tree";
@@ -153,8 +154,8 @@
 			const { tree, prsRawJson } = await fetchEpicTree();
 			const prLinks = extractPrIssueLinks(prsRawJson);
 			const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
-			const sessions = await getClaudeSessions();
-			epicData = mergeSessionsIntoTree(treeWithPrs, sessions);
+			const [sessions, mapping] = await Promise.all([getClaudeSessions(), getAllMappings()]);
+			epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
 			epicError = null;
 		} catch (e: unknown) {
 			epicError = e instanceof Error ? e.message : "Failed to fetch epic tree";
@@ -215,9 +216,9 @@
 				const { tree, prsRawJson } = await fetchEpicTree();
 				const prLinks = extractPrIssueLinks(prsRawJson);
 				const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
-				const sessions = await getClaudeSessions();
+				const [sessions, mapping] = await Promise.all([getClaudeSessions(), getAllMappings()]);
 				if (!cancelled) {
-					epicData = mergeSessionsIntoTree(treeWithPrs, sessions);
+					epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
 				}
 			} catch (e: unknown) {
 				if (!cancelled) {
@@ -264,10 +265,10 @@
 				activeTabUrl = message.url;
 			}
 			if (isClaudeSessionsUpdatedEvent(message)) {
-				getClaudeSessions()
-					.then((sessions) => {
+				Promise.all([getClaudeSessions(), getAllMappings()])
+					.then(([sessions, mapping]) => {
 						if (epicData) {
-							epicData = mergeSessionsIntoTree(epicData, sessions);
+							epicData = mergeSessionsIntoTree(epicData, sessions, mapping);
 						}
 					})
 					.catch((err: unknown) => {

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -4,12 +4,13 @@ import { chromeSendMessage, subscribeToMessages } from "../adapter/chrome/messag
 import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
 import { TabNavigationAdapter } from "../adapter/chrome/tab-navigation.adapter";
 import type { EpicTreeDto } from "../domain/ports/epic-processor.port";
-import type { ClaudeSessionStorage } from "../shared/types/claude-session";
+import type { ClaudeSessionStorage, SessionIssueMapping } from "../shared/types/claude-session";
 import type { DebugState } from "../shared/types/messages";
 import { createAuthUseCase } from "../shared/usecase/auth.usecase";
 import { createDeviceFlowController } from "../shared/usecase/device-flow.controller";
 import { createPrUseCase } from "../shared/usecase/pr.usecase";
 import { createTabNavigationUseCase } from "../shared/usecase/tab-navigation.usecase";
+import { getAllMappings } from "../shared/utils/session-mapping-store";
 import type { WorkspaceResources } from "../shared/utils/workspace-resources";
 import App from "./App.svelte";
 import { createPinnedTabsStore } from "./stores/pinned-tabs.svelte";
@@ -62,6 +63,10 @@ async function getDebugState(): Promise<DebugState> {
 	return response.data;
 }
 
+async function getSessionIssueMappings(): Promise<SessionIssueMapping> {
+	return getAllMappings();
+}
+
 const app = mount(App, {
 	target,
 	props: {
@@ -69,6 +74,7 @@ const app = mount(App, {
 		prUseCase,
 		fetchEpicTree,
 		getClaudeSessions,
+		getSessionIssueMappings,
 		deviceFlowController,
 		subscribeToMessages,
 		pinnedTabsStore,

--- a/src/sidepanel/usecase/merge-sessions.ts
+++ b/src/sidepanel/usecase/merge-sessions.ts
@@ -1,12 +1,24 @@
 import type { EpicTreeDto, TreeNodeDto } from "../../domain/ports/epic-processor.port";
-import type { ClaudeSession, ClaudeSessionStorage } from "../../shared/types/claude-session";
+import type {
+	ClaudeSession,
+	ClaudeSessionStorage,
+	SessionIssueMapping,
+} from "../../shared/types/claude-session";
+import { extractSessionIdFromUrl } from "../../shared/utils/session-id";
+
+/**
+ * ツリー配置決定済みのセッション。`isManuallyMapped` は UI バッジ表示用 (Epic #43)。
+ */
+type ResolvedSession = ClaudeSession & { readonly isManuallyMapped: boolean };
 
 /**
  * 同一タイトルのセッションを重複排除し、各タイトルで最新のもののみ残す。
  * 同じ Issue に対して複数セッション URL が存在するケースに対応。
  */
-function deduplicateSessionsByTitle(sessions: readonly ClaudeSession[]): readonly ClaudeSession[] {
-	const byTitle = new Map<string, ClaudeSession>();
+function deduplicateSessionsByTitle(
+	sessions: readonly ResolvedSession[],
+): readonly ResolvedSession[] {
+	const byTitle = new Map<string, ResolvedSession>();
 	for (const s of sessions) {
 		const existing = byTitle.get(s.title);
 		if (!existing || s.detectedAt > existing.detectedAt) {
@@ -44,32 +56,73 @@ function deduplicateSessionsAcrossIssues(sessions: ClaudeSessionStorage): Claude
 }
 
 /**
+ * storage に載っている全セッションに対し、regex 抽出結果と手動マッピングの union で
+ * 最終的な配置 issueNumber を決定する。
+ *
+ * 手動マッピング (sessionId → issueNumber) が regex 抽出結果より優先される。
+ * sessionId が URL から抽出できないセッションは手動マッピング評価の対象外とし、
+ * regex 抽出結果 (= storage の key) でそのまま配置する。
+ */
+function resolveEffectivePlacement(
+	sessions: ClaudeSessionStorage,
+	mapping: SessionIssueMapping,
+): ReadonlyMap<number, readonly ResolvedSession[]> {
+	const result = new Map<number, ResolvedSession[]>();
+	for (const [issueKey, list] of Object.entries(sessions)) {
+		const regexIssueNum = Number(issueKey);
+		for (const session of list) {
+			const sessionId = extractSessionIdFromUrl(session.sessionUrl);
+			const manualIssueNum = sessionId !== null ? mapping[sessionId] : undefined;
+			const isManuallyMapped = manualIssueNum !== undefined;
+			const effectiveIssueNum = manualIssueNum ?? regexIssueNum;
+			const placed: ResolvedSession = { ...session, isManuallyMapped };
+			const bucket = result.get(effectiveIssueNum);
+			if (bucket) {
+				bucket.push(placed);
+			} else {
+				result.set(effectiveIssueNum, [placed]);
+			}
+		}
+	}
+	return result;
+}
+
+/**
  * セッション情報をエピックツリーにマージする。
  * Issue ノードの子として、対応するセッションノードを追加する。
  * 純粋関数: 元のツリーは変更しない。
+ *
+ * @param mapping regex 抽出を上書きする手動マッピング (Epic #43)。未設定時は空オブジェクト。
  */
 export function mergeSessionsIntoTree(
 	tree: EpicTreeDto,
 	sessions: ClaudeSessionStorage,
+	mapping: SessionIssueMapping,
 ): EpicTreeDto {
 	const cleaned = deduplicateSessionsAcrossIssues(sessions);
+	const byEffectiveIssue = resolveEffectivePlacement(cleaned, mapping);
 	return {
-		roots: tree.roots.map((root) => mergeSessionsIntoNode(root, cleaned)),
+		roots: tree.roots.map((root) => mergeSessionsIntoNode(root, byEffectiveIssue)),
 	};
 }
 
-function mergeSessionsIntoNode(node: TreeNodeDto, sessions: ClaudeSessionStorage): TreeNodeDto {
+function mergeSessionsIntoNode(
+	node: TreeNodeDto,
+	byEffectiveIssue: ReadonlyMap<number, readonly ResolvedSession[]>,
+): TreeNodeDto {
 	if (node.kind.type === "issue") {
 		const issueNumber = node.kind.number;
-		const issueSessions = sessions[String(issueNumber)] ?? [];
-		// 同一タイトルのセッションは最新のもののみ表示 (複数セッション URL の重複を防ぐ)
+		const issueSessions = byEffectiveIssue.get(issueNumber) ?? [];
 		const uniqueSessions = deduplicateSessionsByTitle(issueSessions);
 		const sessionChildren: readonly TreeNodeDto[] = uniqueSessions.map((s) => ({
 			kind: {
 				type: "session" as const,
 				title: s.title,
 				url: s.sessionUrl,
-				issueNumber: s.issueNumber,
+				// 配置先 issue に合わせて effective issueNumber を採用する
+				// (手動マッピングで移動したセッションは移動先を指す)
+				issueNumber,
+				isManuallyMapped: s.isManuallyMapped,
 			},
 			children: [] as readonly TreeNodeDto[],
 			depth: node.depth + 1,
@@ -78,7 +131,7 @@ function mergeSessionsIntoNode(node: TreeNodeDto, sessions: ClaudeSessionStorage
 		return {
 			...node,
 			children: [
-				...node.children.map((c) => mergeSessionsIntoNode(c, sessions)),
+				...node.children.map((c) => mergeSessionsIntoNode(c, byEffectiveIssue)),
 				...sessionChildren,
 			],
 		};
@@ -86,6 +139,6 @@ function mergeSessionsIntoNode(node: TreeNodeDto, sessions: ClaudeSessionStorage
 
 	return {
 		...node,
-		children: node.children.map((c) => mergeSessionsIntoNode(c, sessions)),
+		children: node.children.map((c) => mergeSessionsIntoNode(c, byEffectiveIssue)),
 	};
 }

--- a/src/sidepanel/usecase/merge-sessions.ts
+++ b/src/sidepanel/usecase/merge-sessions.ts
@@ -12,8 +12,12 @@ import { extractSessionIdFromUrl } from "../../shared/utils/session-id";
 type ResolvedSession = ClaudeSession & { readonly isManuallyMapped: boolean };
 
 /**
- * 同一タイトルのセッションを重複排除し、各タイトルで最新のもののみ残す。
- * 同じ Issue に対して複数セッション URL が存在するケースに対応。
+ * 同一タイトルのセッションを重複排除し、各タイトルで代表 1 件のみ残す。
+ *
+ * tiebreaker:
+ *   1. 手動マッピング済み (`isManuallyMapped: true`) を優先する。ユーザーの明示的操作を
+ *      新しい regex 由来セッションが飲み込んで UI から消すのを防ぐ。
+ *   2. 同じ `isManuallyMapped` の場合は `detectedAt` が新しい方を採用する。
  */
 function deduplicateSessionsByTitle(
 	sessions: readonly ResolvedSession[],
@@ -21,7 +25,18 @@ function deduplicateSessionsByTitle(
 	const byTitle = new Map<string, ResolvedSession>();
 	for (const s of sessions) {
 		const existing = byTitle.get(s.title);
-		if (!existing || s.detectedAt > existing.detectedAt) {
+		if (!existing) {
+			byTitle.set(s.title, s);
+			continue;
+		}
+		// 手動マッピング優先 (既存が手動なら置き換えない)
+		if (existing.isManuallyMapped && !s.isManuallyMapped) continue;
+		// 新規が手動で既存が非手動なら置き換え、それ以外は detectedAt で決定
+		if (s.isManuallyMapped && !existing.isManuallyMapped) {
+			byTitle.set(s.title, s);
+			continue;
+		}
+		if (s.detectedAt > existing.detectedAt) {
 			byTitle.set(s.title, s);
 		}
 	}
@@ -70,10 +85,14 @@ function resolveEffectivePlacement(
 	const result = new Map<number, ResolvedSession[]>();
 	for (const [issueKey, list] of Object.entries(sessions)) {
 		const regexIssueNum = Number(issueKey);
+		const hasValidRegexKey = Number.isInteger(regexIssueNum) && regexIssueNum > 0;
 		for (const session of list) {
 			const sessionId = extractSessionIdFromUrl(session.sessionUrl);
 			const manualIssueNum = sessionId !== null ? mapping[sessionId] : undefined;
 			const isManuallyMapped = manualIssueNum !== undefined;
+			// regex key が非正整数 (NaN/0/負値/非数値) の場合は手動マッピングがあれば救済し、
+			// なければ effective placement を諦める (どの Issue ノードにも合致しない)。
+			if (manualIssueNum === undefined && !hasValidRegexKey) continue;
 			const effectiveIssueNum = manualIssueNum ?? regexIssueNum;
 			const placed: ResolvedSession = { ...session, isManuallyMapped };
 			const bucket = result.get(effectiveIssueNum);

--- a/src/test/shared/utils/session-id.test.ts
+++ b/src/test/shared/utils/session-id.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { SESSION_ID_PATTERN, isValidSessionId } from "../../../shared/utils/session-id";
+import {
+	SESSION_ID_PATTERN,
+	extractSessionIdFromUrl,
+	isValidSessionId,
+} from "../../../shared/utils/session-id";
 
 describe("SESSION_ID_PATTERN", () => {
 	it("session_ + 英数字のみのIDにマッチする", () => {
@@ -75,5 +79,47 @@ describe("isValidSessionId", () => {
 	it("129 文字以上の suffix に対して false を返す", () => {
 		const suffix129 = "a".repeat(129);
 		expect(isValidSessionId(`session_${suffix129}`)).toBe(false);
+	});
+});
+
+describe("extractSessionIdFromUrl", () => {
+	it("claude.ai/code のセッション URL から sessionId を抽出する", () => {
+		expect(extractSessionIdFromUrl("https://claude.ai/code/session_01T7hN9fW6KuKZxn52isYdyR")).toBe(
+			"session_01T7hN9fW6KuKZxn52isYdyR",
+		);
+	});
+
+	it("ハイフン・アンダースコア入りの sessionId も抽出する", () => {
+		expect(
+			extractSessionIdFromUrl(
+				"https://claude.ai/code/session_09baa7d1-8aaf-4a38-8a2d-e56c3256a0c0",
+			),
+		).toBe("session_09baa7d1-8aaf-4a38-8a2d-e56c3256a0c0");
+	});
+
+	it("末尾スラッシュ付き URL からも抽出する", () => {
+		expect(extractSessionIdFromUrl("https://claude.ai/code/session_abc123/")).toBe(
+			"session_abc123",
+		);
+	});
+
+	it("クエリ・フラグメントが付いていても末尾セグメントのみ評価する", () => {
+		expect(extractSessionIdFromUrl("https://claude.ai/code/session_abc123?foo=bar")).toBe(
+			"session_abc123",
+		);
+		expect(extractSessionIdFromUrl("https://claude.ai/code/session_abc123#frag")).toBe(
+			"session_abc123",
+		);
+	});
+
+	it("末尾セグメントが SESSION_ID_PATTERN に合致しない場合は null を返す", () => {
+		expect(extractSessionIdFromUrl("https://claude.ai/code/")).toBeNull();
+		expect(extractSessionIdFromUrl("https://claude.ai/code/new")).toBeNull();
+		expect(extractSessionIdFromUrl("https://claude.ai/code/draft_abc")).toBeNull();
+	});
+
+	it("無効な URL 文字列に対しては null を返す", () => {
+		expect(extractSessionIdFromUrl("not-a-url")).toBeNull();
+		expect(extractSessionIdFromUrl("")).toBeNull();
 	});
 });

--- a/src/test/shared/utils/session-id.test.ts
+++ b/src/test/shared/utils/session-id.test.ts
@@ -122,4 +122,12 @@ describe("extractSessionIdFromUrl", () => {
 		expect(extractSessionIdFromUrl("not-a-url")).toBeNull();
 		expect(extractSessionIdFromUrl("")).toBeNull();
 	});
+
+	it("https://claude.ai 以外のオリジンは拒否する (scheme/host 検証)", () => {
+		// javascript:/data: 等のスキーム混入や、フィッシングドメインが mapping lookup に侵入するのを防ぐ。
+		expect(extractSessionIdFromUrl("http://claude.ai/code/session_abc")).toBeNull();
+		expect(extractSessionIdFromUrl("https://evil.example.com/code/session_abc")).toBeNull();
+		expect(extractSessionIdFromUrl("javascript:session_abc")).toBeNull();
+		expect(extractSessionIdFromUrl("data:text/plain,session_abc")).toBeNull();
+	});
 });

--- a/src/test/shared/utils/session-mapping-store.test.ts
+++ b/src/test/shared/utils/session-mapping-store.test.ts
@@ -181,6 +181,50 @@ describe("session-mapping-store", () => {
 		it("空ストレージでは {} を返す", async () => {
 			await expect(getAllMappings()).resolves.toEqual({});
 		});
+
+		it("ストレージに不正な型が混入していた場合は {} を返す (ランタイム検証)", async () => {
+			// 外部拡張や devtools 経由でストレージが汚染されても信頼しない。
+			// 型アサーションだけでは誤った値が mergeSessionsIntoTree まで流れ込むため防御する。
+			const mock = (
+				chrome.storage.local as unknown as {
+					get: { mockImplementationOnce: (fn: () => Promise<unknown>) => void };
+				}
+			).get;
+			mock.mockImplementationOnce(async () => ({ [STORAGE_KEY]: "not-an-object" }));
+			await expect(getAllMappings()).resolves.toEqual({});
+		});
+
+		it("値側が非正整数のエントリはスキップされる (key は妥当だが value が壊れているケース)", async () => {
+			const mock = (
+				chrome.storage.local as unknown as {
+					get: { mockImplementationOnce: (fn: () => Promise<unknown>) => void };
+				}
+			).get;
+			mock.mockImplementationOnce(async () => ({
+				[STORAGE_KEY]: {
+					[VALID_SESSION_A]: 1,
+					[VALID_SESSION_B]: -5,
+					[VALID_SESSION_C]: "10",
+				},
+			}));
+			await expect(getAllMappings()).resolves.toEqual({ [VALID_SESSION_A]: 1 });
+		});
+
+		it("キー側が sessionId パターンに合致しないエントリはスキップされる", async () => {
+			const mock = (
+				chrome.storage.local as unknown as {
+					get: { mockImplementationOnce: (fn: () => Promise<unknown>) => void };
+				}
+			).get;
+			mock.mockImplementationOnce(async () => ({
+				[STORAGE_KEY]: {
+					[VALID_SESSION_A]: 1,
+					[INVALID_SESSION]: 2,
+					__proto__: 3,
+				},
+			}));
+			await expect(getAllMappings()).resolves.toEqual({ [VALID_SESSION_A]: 1 });
+		});
 	});
 
 	describe("race condition", () => {

--- a/src/test/shared/utils/workspace-resources.test.ts
+++ b/src/test/shared/utils/workspace-resources.test.ts
@@ -51,6 +51,7 @@ function createSessionChild(url: string, issueNumber: number): TreeNodeDto {
 			title: "Investigate Issue #42",
 			url,
 			issueNumber,
+			isManuallyMapped: false,
 		},
 		children: [],
 		depth: 2,

--- a/src/test/sidepanel/components/MainScreen.test.ts
+++ b/src/test/sidepanel/components/MainScreen.test.ts
@@ -56,6 +56,7 @@ function createDefaultProps() {
 		fetchPrs: createMockFetchPrs(),
 		fetchEpicTree: createMockFetchEpicTree(),
 		getClaudeSessions: createMockGetClaudeSessions(),
+		getSessionIssueMappings: vi.fn(async () => ({})),
 		getCachedPrs: createMockGetCachedPrs(),
 		loadPrsWithCache: createMockLoadPrsWithCache(),
 		subscribeToMessages: createMockSubscribeToMessages(),

--- a/src/test/sidepanel/usecase/find-node-in-tree.test.ts
+++ b/src/test/sidepanel/usecase/find-node-in-tree.test.ts
@@ -98,6 +98,7 @@ describe("findNodeInTree", () => {
 				title: "Claude session",
 				url: "https://claude.ai/code/session_abc",
 				issueNumber: 500,
+				isManuallyMapped: false,
 			},
 			children: [],
 			depth: 2,
@@ -162,6 +163,7 @@ describe("nodeKeyFor", () => {
 				title: "S",
 				url: "https://claude.ai/code/session_abc",
 				issueNumber: 10,
+				isManuallyMapped: false,
 			}),
 		).toBe("session-10-https://claude.ai/code/session_abc");
 	});

--- a/src/test/sidepanel/usecase/merge-sessions.test.ts
+++ b/src/test/sidepanel/usecase/merge-sessions.test.ts
@@ -561,6 +561,105 @@ describe("mergeSessionsIntoTree", () => {
 			expect(issue10.children).toHaveLength(0);
 		});
 
+		it("同タイトル衝突時、手動マッピング済みセッションが regex のみのセッションより優先される", () => {
+			// detectedAt だけを基準にすると、新しい regex セッションが古い手動マッピングセッションを
+			// 飲み込んで UI から消える。手動操作は意図的行為なので保護する。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"999": [
+					{
+						sessionUrl: "https://claude.ai/code/session_manualOld",
+						title: "Same title",
+						issueNumber: 999,
+						detectedAt: "2026-04-01T00:00:00Z",
+						isLive: false,
+					},
+				],
+				"10": [
+					{
+						sessionUrl: "https://claude.ai/code/session_regexNew",
+						title: "Same title",
+						issueNumber: 10,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: true,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_manualOld: 10 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(1);
+			if (issueNode.children[0].kind.type === "session") {
+				expect(issueNode.children[0].kind.url).toBe("https://claude.ai/code/session_manualOld");
+				expect(issueNode.children[0].kind.isManuallyMapped).toBe(true);
+			}
+		});
+
+		it("storage key が非正整数 ('0'/'-1'/'abc') のセッションは effective issue 判定から除外される", () => {
+			// Number(issueKey) が NaN/0/負値のケースは watcher 側で発生し得ないが、
+			// storage 汚染や旧スキーマ混入への防御としてガードする。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"0": [
+					{
+						sessionUrl: "https://claude.ai/code/session_badKey",
+						title: "bad key session",
+						issueNumber: 0,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: false,
+					},
+				],
+				abc: [
+					{
+						sessionUrl: "https://claude.ai/code/session_alphaKey",
+						title: "alpha key session",
+						issueNumber: 0,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: false,
+					},
+				],
+			};
+
+			// 手動マッピングなしでは tree に現れない (規定外 key は NaN/0 バケットに入って無視される)
+			const result = mergeSessionsIntoTree(tree, sessions, {});
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(0);
+		});
+
+		it("storage key が非正整数でも手動マッピングがあれば Issue 配下に配置される", () => {
+			// 非正整数 key のセッション本体は storage に存在するため、手動マッピング経由で救済できる。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"0": [
+					{
+						sessionUrl: "https://claude.ai/code/session_rescueMe",
+						title: "rescued session",
+						issueNumber: 0,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: false,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_rescueMe: 10 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(1);
+			if (issueNode.children[0].kind.type === "session") {
+				expect(issueNode.children[0].kind.isManuallyMapped).toBe(true);
+			}
+		});
+
 		it("sessionUrl から sessionId を抽出できない場合、手動マッピングの評価から除外される", () => {
 			// 壊れた URL の場合 regex 抽出結果にフォールバック (isManuallyMapped=false)。
 			const tree: EpicTreeDto = {

--- a/src/test/sidepanel/usecase/merge-sessions.test.ts
+++ b/src/test/sidepanel/usecase/merge-sessions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { EpicTreeDto, TreeNodeDto } from "../../../domain/ports/epic-processor.port";
-import type { ClaudeSessionStorage } from "../../../shared/types/claude-session";
+import type {
+	ClaudeSessionStorage,
+	SessionIssueMapping,
+} from "../../../shared/types/claude-session";
 import { mergeSessionsIntoTree } from "../../../sidepanel/usecase/merge-sessions";
 
 function makeIssueNode(
@@ -45,7 +48,7 @@ describe("mergeSessionsIntoTree", () => {
 		};
 		const sessions: ClaudeSessionStorage = {};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].children).toHaveLength(1);
@@ -67,7 +70,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issueNode = result.roots[0].children[0];
 		expect(issueNode.children).toHaveLength(1);
@@ -95,7 +98,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const sessionNode = result.roots[0].children[0].children[0];
 		expect(sessionNode.depth).toBe(3);
@@ -124,7 +127,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issueNode = result.roots[0].children[0];
 		expect(issueNode.children).toHaveLength(2);
@@ -166,7 +169,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issueNode = result.roots[0].children[0];
 		expect(issueNode.children).toHaveLength(2);
@@ -191,7 +194,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		mergeSessionsIntoTree(tree, sessions);
+		mergeSessionsIntoTree(tree, sessions, {});
 
 		// Original tree must be unchanged
 		expect(originalIssue.children).toHaveLength(0);
@@ -216,7 +219,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const deepNode = result.roots[0].children[0].children[0];
 		expect(deepNode.children).toHaveLength(1);
@@ -240,7 +243,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		expect(result.roots[0].children[0].children[0].children).toEqual([]);
 	});
@@ -261,7 +264,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		expect(result.roots[0].children[0].children).toHaveLength(0);
 	});
@@ -296,7 +299,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issueNode = result.roots[0].children[0];
 		// 3つのセッションが同一タイトルなので最新の1つだけ表示
@@ -329,7 +332,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issueNode = result.roots[0].children[0];
 		// タイトルが異なるので両方表示
@@ -362,7 +365,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issue10 = result.roots[0].children[0];
 		const issue20 = result.roots[0].children[1];
@@ -413,7 +416,7 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		const issue10 = result.roots[0].children[0];
 		const issue20 = result.roots[0].children[1];
@@ -440,8 +443,149 @@ describe("mergeSessionsIntoTree", () => {
 			],
 		};
 
-		const result = mergeSessionsIntoTree(tree, sessions);
+		const result = mergeSessionsIntoTree(tree, sessions, {});
 
 		expect(result.roots).toHaveLength(0);
+	});
+
+	// Phase 2 (Issue #46): 手動マッピング統合
+	describe("SessionIssueMapping 統合", () => {
+		it("regex 抽出が null でも手動マッピングがあれば該当 Issue 配下に配置される", () => {
+			// 規模: storage には regex で拾えなかったため該当セッションが存在しないシナリオを
+			// 「規定外 issueNumber (tree に存在しない) 配下に格納されている」で模する。
+			// 手動マッピングで tree 内の Issue 10 に付け替える。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"999": [
+					{
+						sessionUrl: "https://claude.ai/code/session_manual01",
+						title: "no issue keyword in title",
+						issueNumber: 999,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: false,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_manual01: 10 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(1);
+			const child = issueNode.children[0];
+			expect(child.kind.type).toBe("session");
+			if (child.kind.type === "session") {
+				expect(child.kind.url).toBe("https://claude.ai/code/session_manual01");
+				expect(child.kind.isManuallyMapped).toBe(true);
+			}
+		});
+
+		it("手動マッピングは regex 抽出結果より優先される", () => {
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10), makeIssueNode(20)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"20": [
+					{
+						sessionUrl: "https://claude.ai/code/session_override1",
+						title: "Investigate #20",
+						issueNumber: 20,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: true,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_override1: 10 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issue10 = result.roots[0].children[0];
+			const issue20 = result.roots[0].children[1];
+			expect(issue10.children).toHaveLength(1);
+			expect(issue20.children).toHaveLength(0);
+			if (issue10.children[0].kind.type === "session") {
+				expect(issue10.children[0].kind.isManuallyMapped).toBe(true);
+			}
+		});
+
+		it("手動マッピングなし・regex ありでは既存動作を維持する", () => {
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"10": [
+					{
+						sessionUrl: "https://claude.ai/code/session_plain1",
+						title: "Inv #10",
+						issueNumber: 10,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: true,
+					},
+				],
+			};
+
+			const result = mergeSessionsIntoTree(tree, sessions, {});
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(1);
+			const child = issueNode.children[0];
+			if (child.kind.type === "session") {
+				expect(child.kind.issueNumber).toBe(10);
+				expect(child.kind.isManuallyMapped).toBe(false);
+			}
+		});
+
+		it("マッピング先 Issue がツリーに存在しない場合、セッションはツリー外になる", () => {
+			// 後続 Phase で orphan セクションとして扱う。Phase 2 ではどこにも表示しない。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"10": [
+					{
+						sessionUrl: "https://claude.ai/code/session_orphan1",
+						title: "#10 session",
+						issueNumber: 10,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: true,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_orphan1: 777 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issue10 = result.roots[0].children[0];
+			expect(issue10.children).toHaveLength(0);
+		});
+
+		it("sessionUrl から sessionId を抽出できない場合、手動マッピングの評価から除外される", () => {
+			// 壊れた URL の場合 regex 抽出結果にフォールバック (isManuallyMapped=false)。
+			const tree: EpicTreeDto = {
+				roots: [makeEpicNode(1, [makeIssueNode(10)])],
+			};
+			const sessions: ClaudeSessionStorage = {
+				"10": [
+					{
+						sessionUrl: "https://example.com/not-a-session-url",
+						title: "#10 weird url",
+						issueNumber: 10,
+						detectedAt: "2026-04-10T00:00:00Z",
+						isLive: false,
+					},
+				],
+			};
+			const mapping: SessionIssueMapping = { session_dummy: 10 };
+
+			const result = mergeSessionsIntoTree(tree, sessions, mapping);
+
+			const issueNode = result.roots[0].children[0];
+			expect(issueNode.children).toHaveLength(1);
+			if (issueNode.children[0].kind.type === "session") {
+				expect(issueNode.children[0].kind.isManuallyMapped).toBe(false);
+			}
+		});
 	});
 });


### PR DESCRIPTION
## 概要
Epic #43 Phase 2。`mergeSessionsIntoTree` を拡張し、regex タイトル抽出で拾えない Claude セッションを `SessionIssueMapping` 経由で手動 Issue 紐付けできるようにする。

## 変更内容
- **`src/shared/utils/session-id.ts`**: `extractSessionIdFromUrl(url)` を追加。`new URL` でパース → 末尾セグメントを `SESSION_ID_PATTERN` で検証
- **`src/sidepanel/usecase/merge-sessions.ts`**: `mergeSessionsIntoTree(tree, sessions, mapping)` に第3引数追加。`resolveEffectivePlacement` で regex 抽出と手動マッピングを union (手動優先) し `isManuallyMapped` フラグを session ノードに付与
- **`src/domain/ports/epic-processor.port.ts`**: `TreeNodeKind` の session variant に `isManuallyMapped: boolean` を追加 (UI バッジ表示用)
- **`rust-core/crates/domain/src/epic.rs`**: Rust `TreeNodeKind::Session` に `is_manually_mapped: bool` (serde `rename = "isManuallyMapped"`) を追加しスキーマ同期
- **`src/sidepanel/components/MainScreen.svelte`**: 3 箇所の `mergeSessionsIntoTree` 呼び出しを `getAllMappings()` 併用に更新
- **テスト**: 手動マッピング統合ケース 5 本 + `extractSessionIdFromUrl` 境界値テスト 6 本を追加

## 関連 Issue
- closes #46
- refs #43 (Epic)

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`) — 0 errors
- [x] フロントエンドテスト通過 (`pnpm test`) — merge-sessions 19/19, session-id 20/20 pass
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 74 passed
- [ ] `/verify` で検証ループ PASS (未実施)

## レビュー観点
- `resolveEffectivePlacement` の「手動マッピングが regex 結果より優先」仕様が正しく実装されているか
- `extractSessionIdFromUrl` の URL パース検証が `javascript:` / `data:` 等のスキームに対して十分か
- `isManuallyMapped` フラグの伝播と配置先 `issueNumber` (effective issue) の扱いが UI 側で整合するか
- Rust スキーマ同期の完全性 (本 PR 時点では Rust 側は Session variant を生成しないため実害はないが、将来の互換性のため `#[serde(default)]` が必要か要検討)

## 指摘事項 (PR 後セルフレビュー反映予定)

`/review` による 4 agent レビューで以下が指摘された:
- **HIGH**: `MainScreen.svelte` の `getAllMappings` 直 import は既存の Props 注入 DI パターンを逸脱
- **HIGH**: `Promise.all([getClaudeSessions(), getAllMappings()])` が一方失敗で全体 reject → `Promise.allSettled` 推奨
- **MEDIUM**: `deduplicateSessionsByTitle` が `isManuallyMapped` を考慮せず、手動マッピング済みセッションが新しい regex 由来セッションに飲み込まれうる
- **MEDIUM**: `resolveEffectivePlacement` の Rust 移譲 (別 Issue 化検討)