### PR TITLE
feat: Claude session に手動 Issue 紐付け UI を追加 (closes #47)

### DIFF
--- a/rust-core/crates/domain/src/epic.rs
+++ b/rust-core/crates/domain/src/epic.rs
@@ -36,6 +36,13 @@ pub enum TreeNodeKind {
         /// 読んだ場合は `false` にフォールバックして後方互換を保つ。
         #[serde(rename = "isManuallyMapped", default)]
         is_manually_mapped: bool,
+        /// 正規 URL から抽出したセッション ID (TS 側 `extractSessionIdFromUrl` 相当)。
+        /// URL が壊れていて抽出できない場合は `None` となる (Issue #47)。
+        /// `#[serde(default)]` で旧キャッシュ JSON (このフィールド無し) を `None` に
+        /// フォールバックさせる。TS 側の `sessionId: string | null` と整合させるため、
+        /// `skip_serializing_if` は付けず、`None` のとき `"sessionId":null` を必ず出力する。
+        #[serde(rename = "sessionId", default)]
+        session_id: Option<String>,
     },
 }
 
@@ -234,6 +241,7 @@ mod tests {
                 url: "https://claude.ai/code/session_123".to_string(),
                 issue_number: 1882,
                 is_manually_mapped: false,
+                session_id: None,
             },
             2,
         );
@@ -264,6 +272,87 @@ mod tests {
             TreeNodeKind::Session {
                 is_manually_mapped, ..
             } => assert!(!is_manually_mapped),
+            other => panic!("expected Session variant, got {other:?}"),
+        }
+    }
+
+    // Phase 3 (Issue #47): Session バリアントに `session_id: Option<String>` を追加する。
+    // TS 側の `TreeNodeKind` (session バリアント) と同じスキーマを持たせ、
+    // sidepanel UI の Link ボタン表示判定で使う。
+    //
+    // このテストは Session に `session_id` フィールドが未定義のためコンパイルエラーで
+    // RED になる。GREEN フェーズでフィールドを追加した時点で解消する想定。
+
+    /// Session ノードをシリアライズすると `"sessionId"` (camelCase) を含むことを確認する。
+    /// Rust 側は `session_id: Option<String>` で、`#[serde(rename = "sessionId")]` を付けて
+    /// TS 側の命名と揃える。
+    #[test]
+    fn session_node_json_has_camel_case_session_id() {
+        let node = TreeNode::new(
+            TreeNodeKind::Session {
+                title: "Inv #42".to_string(),
+                url: "https://claude.ai/code/session_abc".to_string(),
+                issue_number: 42,
+                is_manually_mapped: false,
+                session_id: Some("session_abc".to_string()),
+            },
+            2,
+        );
+        let json = serde_json::to_string(&node).expect("serialize");
+        eprintln!("Session node JSON: {json}");
+        assert!(
+            json.contains("\"sessionId\""),
+            "expected sessionId in JSON, got: {json}"
+        );
+        assert!(
+            json.contains("\"session_abc\""),
+            "expected session_abc value in JSON, got: {json}"
+        );
+    }
+
+    /// LOW-4 (Phase 3b レビュー指摘): `session_id` が `None` のときも
+    /// JSON 出力に `"sessionId":null` が含まれることを保証する。
+    /// TS 側の `sessionId: string | null` と整合させるため、
+    /// `#[serde(skip_serializing_if = "Option::is_none")]` を付けて undefined 扱いに
+    /// してしまうと TS 側の型契約と破綻する。明示的に null 出力されることを契約として固定する。
+    #[test]
+    fn session_node_json_emits_null_when_session_id_is_none() {
+        let node = TreeNode::new(
+            TreeNodeKind::Session {
+                title: "No session id".to_string(),
+                url: "https://claude.ai/code/unknown".to_string(),
+                issue_number: 1,
+                is_manually_mapped: false,
+                session_id: None,
+            },
+            2,
+        );
+        let json = serde_json::to_string(&node).expect("serialize");
+        eprintln!("Session node JSON (None): {json}");
+        assert!(
+            json.contains("\"sessionId\":null"),
+            "expected sessionId:null in JSON, got: {json}"
+        );
+    }
+
+    /// `sessionId` フィールドを持たない旧キャッシュ JSON を deserialize しても
+    /// `#[serde(default)]` で `session_id == None` にフォールバックすることを確認する。
+    #[test]
+    fn session_node_deserializes_legacy_json_without_session_id() {
+        let legacy_json = r#"{
+            "kind": {
+                "type": "session",
+                "title": "legacy session without sessionId",
+                "url": "https://claude.ai/code/session_legacy2",
+                "issueNumber": 99,
+                "isManuallyMapped": false
+            },
+            "children": [],
+            "depth": 2
+        }"#;
+        let node: TreeNode = serde_json::from_str(legacy_json).expect("deserialize legacy JSON");
+        match node.kind {
+            TreeNodeKind::Session { session_id, .. } => assert_eq!(session_id, None),
             other => panic!("expected Session variant, got {other:?}"),
         }
     }

--- a/src/domain/ports/epic-processor.port.ts
+++ b/src/domain/ports/epic-processor.port.ts
@@ -42,6 +42,13 @@ export type TreeNodeKind =
 			 * regex 抽出のみで配置された場合は `false`。UI バッジ表示用。
 			 */
 			readonly isManuallyMapped: boolean;
+			/**
+			 * 正規 URL から抽出したセッション ID (`extractSessionIdFromUrl` の戻り値)。
+			 * URL が壊れていて抽出できない場合は `null`。
+			 * Rust 側の `session_id: Option<String>` と対応 (Issue #47)。
+			 * LinkSessionDialog 表示判定および手動マッピング書き込み時のキーに使う。
+			 */
+			readonly sessionId: string | null;
 	  };
 
 export interface TreeNodeDto {

--- a/src/shared/utils/session-mapping-subscribe.ts
+++ b/src/shared/utils/session-mapping-subscribe.ts
@@ -1,0 +1,31 @@
+/**
+ * `sessionIssueMapping` (chrome.storage.local) の変更を購読するユーティリティ。
+ *
+ * 背景:
+ *   Sidepanel から setMapping で書き込まれた内容を、同じ Sidepanel 側の UI ツリーに
+ *   即座に反映するため、storage 変更イベントを subscribe する必要がある。
+ *   chrome.* API 呼び出しは `src/shared/` または `src/background/` に集約する規約に従い、
+ *   Svelte コンポーネントから直接 chrome API を触らずこのモジュール経由で購読する。
+ *
+ * 仕様:
+ *   - `area === "local"` かつ `STORAGE_KEY` が changes に含まれるときのみ callback を呼ぶ
+ *   - 他キーや他 area の変更ではコールバックを呼ばない (無駄な再描画を防ぐ)
+ *   - 戻り値は unsubscribe 関数 (Svelte `$effect` の cleanup に渡す想定)
+ */
+
+const STORAGE_KEY = "sessionIssueMapping";
+
+export function subscribeToMappingChanges(callback: () => void): () => void {
+	const listener = (
+		changes: { [key: string]: chrome.storage.StorageChange },
+		area: chrome.storage.AreaName,
+	): void => {
+		if (area !== "local") return;
+		if (!(STORAGE_KEY in changes)) return;
+		callback();
+	};
+	chrome.storage.onChanged.addListener(listener);
+	return () => {
+		chrome.storage.onChanged.removeListener(listener);
+	};
+}

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -19,13 +19,14 @@
 		getSessionIssueMappings: () => Promise<SessionIssueMapping>;
 		deviceFlowController: DeviceFlowController;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
+		subscribeToMappingChanges?: (callback: () => void) => () => void;
 		pinnedTabsStore: PinnedTabsStore;
 		onNavigate?: (url: string) => void;
 		onOpenWorkspace?: (resources: WorkspaceResources) => void;
 		getCurrentTabUrl?: () => Promise<string | null>;
 		getDebugState?: () => Promise<DebugState>;
 	};
-	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, deviceFlowController, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+	const { authUseCase, prUseCase, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, deviceFlowController, subscribeToMessages, subscribeToMappingChanges, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
 
 	let authenticated = $state(false);
 	let loading = $state(true);
@@ -65,7 +66,7 @@
 		<p>Loading...</p>
 	</div>
 {:else if authenticated}
-	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} {getSessionIssueMappings} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} {getDebugState} />
+	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} {fetchEpicTree} {getClaudeSessions} {getSessionIssueMappings} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {subscribeToMappingChanges} {pinnedTabsStore} {onNavigate} {onOpenWorkspace} {getCurrentTabUrl} {getDebugState} />
 {:else}
 	<LoginScreen controller={deviceFlowController} />
 {/if}

--- a/src/sidepanel/components/LinkSessionDialog.svelte
+++ b/src/sidepanel/components/LinkSessionDialog.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import { flushSync, onDestroy } from "svelte";
+	import { setMapping as defaultSetMapping } from "../../shared/utils/session-mapping-store";
+	import { extractIssueNumberCandidates } from "../usecase/extract-issue-number-candidates";
+
+	type Props = {
+		title: string;
+		sessionId: string;
+		onClose: () => void;
+		setMapping?: (sessionId: string, issueNumber: number) => Promise<void>;
+	};
+
+	const { title, sessionId, onClose, setMapping = defaultSetMapping }: Props = $props();
+
+	let inputValue = $state("");
+	let errorMessage = $state<string | null>(null);
+	let busy = $state(false);
+	// ダイアログ本体 (role=dialog の div) への参照。Esc の keydown をここで受けるのと、
+	// mount 直後に初期フォーカスを当てるために使う。
+	let dialogEl: HTMLDivElement | null = $state(null);
+
+	// submit の await 中にコンポーネントが unmount された場合に destroyed state への
+	// 書き込みを防ぐためのフラグ。onDestroy で false にする。
+	let mounted = true;
+	onDestroy(() => {
+		mounted = false;
+	});
+
+	const candidates = $derived(extractIssueNumberCandidates(title));
+
+	// `Number.parseInt` は "1.5" も 1 として受理し、さらに "001" を 1 に潰すため、
+	// 入力文字列が「先頭ゼロなしの正整数」であることを正規表現で追加検証する。
+	// これにより「0」「001」「負数」「小数」「非数値」を submit 前に弾き、
+	// UI 表示 (文字列) と mapping 書き込み (整数) の乖離を防ぐ。
+	const INTEGER_PATTERN = /^[1-9]\d*$/;
+	const parsed = $derived(Number.parseInt(inputValue, 10));
+	const isValid = $derived(
+		INTEGER_PATTERN.test(inputValue) && Number.isInteger(parsed) && parsed > 0,
+	);
+
+	function handleChipClick(candidate: string): void {
+		// テストで同期的に DOM 状態を検証できるよう、および連続したユーザー操作で
+		// ちらつきを防ぐため明示的に同期化する。
+		flushSync(() => {
+			inputValue = candidate;
+		});
+	}
+
+	function handleCancel(): void {
+		onClose();
+	}
+
+	async function handleSubmit(event: SubmitEvent): Promise<void> {
+		event.preventDefault();
+		if (!isValid || busy) return;
+		busy = true;
+		errorMessage = null;
+		try {
+			await setMapping(sessionId, parsed);
+			// unmount 後の state 書き込みを避ける (onClose の呼び出しは許容)。
+			if (!mounted) return;
+			onClose();
+		} catch (e: unknown) {
+			if (!mounted) return;
+			// サイレントフォールバックを避けるため、ログ + UI 両方で通知する。
+			const message = e instanceof Error ? e.message : String(e);
+			errorMessage = message;
+			console.error("[LinkSessionDialog] setMapping failed:", e);
+		} finally {
+			// unmount 後の $state 書き込みは Svelte のランタイム警告を招くため mounted を確認。
+			if (mounted) busy = false;
+		}
+	}
+
+	// Esc キーはダイアログ本体 (focus が当たっている間) のみで処理する。
+	// window 登録だと複数ダイアログが同時オープンしたとき全てが反応する問題があるため
+	// ダイアログ要素に限定し、かつ stopPropagation で外側に伝播させない。
+	function handleKeydown(e: KeyboardEvent): void {
+		if (e.key !== "Escape") return;
+		e.stopPropagation();
+		e.preventDefault();
+		onClose();
+	}
+
+	// mount 後、Esc を受け取れるようにダイアログ本体に初期フォーカスを当てる。
+	// tabindex="-1" により JS からの focus() が可能。ユーザーはチップ / input に
+	// Tab で移動できる (最低限の focus 起点提供; 完全な focus trap は別 Issue)。
+	$effect(() => {
+		dialogEl?.focus();
+	});
+</script>
+
+<!-- overlay はクリックで閉じない設計 (誤操作で未送信状態を失わないため) -->
+<div class="link-session-overlay">
+	<div
+		bind:this={dialogEl}
+		class="link-session-dialog"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="link-session-dialog-title"
+		tabindex="-1"
+		onkeydown={handleKeydown}
+	>
+		<h2 id="link-session-dialog-title" class="link-session-title">Issue に紐付け</h2>
+		<p class="link-session-subtitle">{title}</p>
+
+		{#if candidates.length > 0}
+			<div class="suggest-chips">
+				{#each candidates as candidate (candidate)}
+					<button
+						type="button"
+						class="issue-suggest-chip"
+						onclick={() => handleChipClick(candidate)}
+					>
+						#{candidate}
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		<form class="link-session-form" onsubmit={handleSubmit}>
+			<label class="input-label" for="issue-number-input">
+				Issue 番号
+				<input
+					id="issue-number-input"
+					class="issue-number-input"
+					type="text"
+					inputmode="numeric"
+					bind:value={inputValue}
+					placeholder="例: 123"
+					disabled={busy}
+				/>
+			</label>
+
+			{#if errorMessage}
+				<div class="link-session-error" role="alert">{errorMessage}</div>
+			{/if}
+
+			<div class="button-row">
+				<button type="button" class="cancel-btn" onclick={handleCancel} disabled={busy}>
+					キャンセル
+				</button>
+				<button type="submit" class="submit-btn" disabled={!isValid || busy}>
+					紐付ける
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
+
+<style>
+	/* overlay は最前面で表示する (サイドパネル内の他要素より上)。 */
+	.link-session-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		/* header (z-index: 10) より上で表示する。将来グローバル定義を導入しやすいよう
+		   CSS 変数 `--z-modal` を優先し、未定義時は 1000 にフォールバックする。 */
+		z-index: var(--z-modal, 1000);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+	}
+
+	.link-session-dialog {
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border-primary);
+		border-radius: 6px;
+		/* sidebar 幅 (~400px) に収まるよう最大幅を絞る */
+		max-width: 360px;
+		width: 100%;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		color: var(--color-text-primary);
+	}
+
+	.link-session-dialog:focus {
+		/* tabindex="-1" による focus リングを出すと UX 上ノイズのため抑制する。 */
+		outline: none;
+	}
+
+	.link-session-title {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.link-session-subtitle {
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		margin: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.suggest-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+	}
+
+	.issue-suggest-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.1875rem 0.5rem;
+		font-size: 0.75rem;
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-border-primary);
+		border-radius: 10px;
+		color: var(--color-text-primary);
+		cursor: pointer;
+		transition: background 0.15s, border-color 0.15s;
+	}
+
+	.issue-suggest-chip:hover {
+		background: var(--color-bg-hover);
+		border-color: var(--color-accent-primary);
+	}
+
+	.link-session-form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.input-label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+	}
+
+	.issue-number-input {
+		padding: 0.375rem 0.5rem;
+		font-size: 0.875rem;
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border-primary);
+		border-radius: 4px;
+		color: var(--color-text-primary);
+	}
+
+	.issue-number-input:focus {
+		outline: none;
+		border-color: var(--color-accent-primary);
+	}
+
+	.link-session-error {
+		padding: 0.375rem 0.5rem;
+		background: rgba(248, 81, 73, 0.1);
+		border: 1px solid var(--color-badge-red);
+		border-radius: 4px;
+		color: var(--color-badge-red);
+		font-size: 0.75rem;
+	}
+
+	.button-row {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.5rem;
+	}
+
+	.cancel-btn,
+	.submit-btn {
+		padding: 0.375rem 0.75rem;
+		font-size: 0.8125rem;
+		border-radius: 4px;
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	.cancel-btn {
+		background: none;
+		border: 1px solid var(--color-border-primary);
+		color: var(--color-text-primary);
+	}
+
+	.submit-btn {
+		background: var(--color-accent-primary);
+		border: 1px solid var(--color-accent-primary);
+		color: var(--color-bg-primary);
+	}
+
+	.cancel-btn:disabled,
+	.submit-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+</style>

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -33,6 +33,7 @@
 		getCachedPrs: () => Promise<CachedPrData | null>;
 		loadPrsWithCache: (minutes: number) => Promise<(ProcessedPrsResult & { hasMore: boolean }) | null>;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
+		subscribeToMappingChanges?: (callback: () => void) => () => void;
 		pinnedTabsStore: PinnedTabsStore;
 		onNavigate?: (url: string) => void;
 		onOpenWorkspace?: (resources: WorkspaceResources) => void;
@@ -40,7 +41,7 @@
 		getDebugState?: () => Promise<DebugState>;
 	};
 
-	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, getCachedPrs, loadPrsWithCache, subscribeToMessages, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
+	const { onLogout, fetchPrs, fetchEpicTree, getClaudeSessions, getSessionIssueMappings, getCachedPrs, loadPrsWithCache, subscribeToMessages, subscribeToMappingChanges, pinnedTabsStore, onNavigate, onOpenWorkspace, getCurrentTabUrl, getDebugState }: Props = $props();
 
 	/**
 	 * sessions と mapping を並行取得する。
@@ -161,6 +162,30 @@
 	let epicData = $state<EpicTreeDto | null>(null);
 	let epicError = $state<string | null>(null);
 	let activeWorkspaceIssueNumber = $state<number | null>(null);
+	// session 未マージ状態のツリーを保持する。session / mapping イベントの再マージ時は
+	// 必ずこれを source に使うことで、epicData (= session マージ済み) を再入力して
+	// session ノードが累積するバグ (Phase 4 HIGH-3) を防ぐ。
+	let treeWithPrs = $state<EpicTreeDto | null>(null);
+
+	/**
+	 * sessions と mapping を取得し、保持している treeWithPrs と結合して epicData を更新する。
+	 * `isClaudeSessionsUpdatedEvent` と `subscribeToMappingChanges` の両方から呼ばれる。
+	 * 両者は重複発火の可能性があるが、source が固定された treeWithPrs なので冪等。
+	 * 失敗時は epicError にメッセージを設定し、本番でも console.error でログする
+	 * (サイレントフォールバック禁止)。
+	 */
+	async function reloadSessionsAndMapping(): Promise<void> {
+		try {
+			const { sessions, mapping } = await fetchSessionsAndMapping();
+			if (treeWithPrs) {
+				epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
+			}
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : "Failed to reload sessions";
+			console.error("[MainScreen] reloadSessionsAndMapping failed:", err);
+			epicError = message;
+		}
+	}
 
 	function handleOpenWorkspace(resources: WorkspaceResources): void {
 		activeWorkspaceIssueNumber = resources.issueNumber;
@@ -182,9 +207,11 @@
 		try {
 			const { tree, prsRawJson } = await fetchEpicTree();
 			const prLinks = extractPrIssueLinks(prsRawJson);
-			const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
+			// treeWithPrs は session 未マージ状態。再マージ時の source として保持する。
+			const nextTreeWithPrs = movePrsToLinkedIssues(tree, prLinks);
 			const { sessions, mapping } = await fetchSessionsAndMapping();
-			epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
+			treeWithPrs = nextTreeWithPrs;
+			epicData = mergeSessionsIntoTree(nextTreeWithPrs, sessions, mapping);
 			epicError = null;
 		} catch (e: unknown) {
 			epicError = e instanceof Error ? e.message : "Failed to fetch epic tree";
@@ -244,10 +271,12 @@
 			try {
 				const { tree, prsRawJson } = await fetchEpicTree();
 				const prLinks = extractPrIssueLinks(prsRawJson);
-				const treeWithPrs = movePrsToLinkedIssues(tree, prLinks);
+				// session 未マージ状態のツリーを保持し、再マージ時の source とする。
+				const nextTreeWithPrs = movePrsToLinkedIssues(tree, prLinks);
 				const { sessions, mapping } = await fetchSessionsAndMapping();
 				if (!cancelled) {
-					epicData = mergeSessionsIntoTree(treeWithPrs, sessions, mapping);
+					treeWithPrs = nextTreeWithPrs;
+					epicData = mergeSessionsIntoTree(nextTreeWithPrs, sessions, mapping);
 				}
 			} catch (e: unknown) {
 				if (!cancelled) {
@@ -294,22 +323,27 @@
 				activeTabUrl = message.url;
 			}
 			if (isClaudeSessionsUpdatedEvent(message)) {
-				fetchSessionsAndMapping()
-					.then(({ sessions, mapping }) => {
-						if (epicData) {
-							epicData = mergeSessionsIntoTree(epicData, sessions, mapping);
-						}
-					})
-					.catch((err: unknown) => {
-						if (import.meta.env.DEV) {
-							console.warn("[MainScreen] claude sessions reload failed:", err);
-						}
-					});
+				// subscribeToMappingChanges と重複発火する可能性があるが、
+				// reloadSessionsAndMapping は treeWithPrs を source とするため冪等。
+				void reloadSessionsAndMapping();
 			}
 		}
 
 		const unsubscribe = subscribeToMessages(onMessage);
 
+		return () => {
+			unsubscribe();
+		};
+	});
+
+	// sessionIssueMapping の更新 (LinkSessionDialog からの書き込み等) を購読して
+	// 手動マッピング反映後にツリーを即座に再構築する。
+	// isClaudeSessionsUpdatedEvent と重複発火する可能性があるが冪等 (common reloader)。
+	$effect(() => {
+		if (!subscribeToMappingChanges) return;
+		const unsubscribe = subscribeToMappingChanges(() => {
+			void reloadSessionsAndMapping();
+		});
 		return () => {
 			unsubscribe();
 		};

--- a/src/sidepanel/components/TreeNode.svelte
+++ b/src/sidepanel/components/TreeNode.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { flushSync } from "svelte";
 	import type { TreeNodeDto } from "../../domain/ports/epic-processor.port";
 	import { safeUrl } from "../../shared/utils/url";
 	import type { WorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { resolveWorkspaceResources } from "../../shared/utils/workspace-resources";
 	import { nodeKeyFor } from "../usecase/find-node-in-tree";
+	import LinkSessionDialog from "./LinkSessionDialog.svelte";
 	import TreeNode from "./TreeNode.svelte";
 
 	type Props = {
@@ -33,6 +35,7 @@
 
 	let open = $state(true);
 	let hovered = $state(false);
+	let linkDialogOpen = $state(false);
 	const hasChildren = $derived(node.children.length > 0);
 	const MAX_INDENT_DEPTH = 3;
 	const displayDepth = $derived(Math.min(node.depth, MAX_INDENT_DEPTH));
@@ -178,7 +181,31 @@
 			<a class="node-title clickable" href={safeUrl(node.kind.type === "session" ? node.kind.url : "")} target="_blank" rel="noopener noreferrer">
 				{node.kind.title}
 			</a>
+			{#if node.kind.isManuallyMapped}
+				<span class="state-badge manual-mapping-badge" title="手動マッピング">manual</span>
+			{/if}
+			{#if node.kind.sessionId}
+				<button
+					class="link-session-btn"
+					onclick={(e) => {
+						e.stopPropagation();
+						e.preventDefault();
+						// テストで同期的に DOM 状態を検証できるよう、および連続したユーザー操作で
+						// ちらつきを防ぐため明示的に同期化する。
+						flushSync(() => { linkDialogOpen = true; });
+					}}
+					aria-label="Link to issue"
+					title="Issue に紐付け"
+				>&#128279;</button>
+			{/if}
 		</div>
+		{#if linkDialogOpen && node.kind.sessionId}
+			<LinkSessionDialog
+				title={node.kind.title}
+				sessionId={node.kind.sessionId}
+				onClose={() => { linkDialogOpen = false; }}
+			/>
+		{/if}
 	{/if}
 
 	{#if open && hasChildren}
@@ -446,6 +473,29 @@
 	}
 
 	.pin-btn:hover {
+		color: var(--color-accent-primary);
+		border-color: var(--color-accent-primary);
+	}
+
+	.state-badge.manual-mapping-badge {
+		background: var(--color-bg-secondary);
+		color: var(--color-text-secondary);
+	}
+
+	.link-session-btn {
+		background: none;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		padding: 0.0625rem 0.25rem;
+		color: var(--color-text-secondary);
+		cursor: pointer;
+		font-size: 0.75rem;
+		flex-shrink: 0;
+		line-height: 1;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.link-session-btn:hover {
 		color: var(--color-accent-primary);
 		border-color: var(--color-accent-primary);
 	}

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -11,6 +11,7 @@ import { createDeviceFlowController } from "../shared/usecase/device-flow.contro
 import { createPrUseCase } from "../shared/usecase/pr.usecase";
 import { createTabNavigationUseCase } from "../shared/usecase/tab-navigation.usecase";
 import { getAllMappings } from "../shared/utils/session-mapping-store";
+import { subscribeToMappingChanges } from "../shared/utils/session-mapping-subscribe";
 import type { WorkspaceResources } from "../shared/utils/workspace-resources";
 import App from "./App.svelte";
 import { createPinnedTabsStore } from "./stores/pinned-tabs.svelte";
@@ -77,6 +78,7 @@ const app = mount(App, {
 		getSessionIssueMappings,
 		deviceFlowController,
 		subscribeToMessages,
+		subscribeToMappingChanges,
 		pinnedTabsStore,
 		onNavigate: (url: string) => tabNavigationUseCase.navigateToPr(url),
 		onOpenWorkspace: async (resources: WorkspaceResources) => {

--- a/src/sidepanel/usecase/extract-issue-number-candidates.ts
+++ b/src/sidepanel/usecase/extract-issue-number-candidates.ts
@@ -1,0 +1,30 @@
+/**
+ * LinkSessionDialog のサジェストチップ用。セッションタイトルから
+ * 「Issue 番号っぽい数字」を抽出する純粋関数。
+ *
+ * 仕様:
+ * - 最小桁数 `MIN_DIGIT_COUNT` 以上の連続数字のみ拾う (2 桁以下はノイズ率が高いため除外)
+ * - 先頭ゼロ ("001" 等) は除外する (Number.parseInt で "1" に潰れ UI 表示と書き込み値が乖離するため)
+ * - 重複除去 (出現順を保つ)
+ * - 最大 `MAX_SUGGESTION_COUNT` 件 (UI のチップ描画上限)
+ */
+
+/** チップ描画の上限。DOM の視認性 (3-5 チップ) を考慮した値。 */
+export const MAX_SUGGESTION_COUNT = 5;
+
+/** Issue 番号として有意とみなす最小桁数。2 桁以下はノイズ (日付・優先度等) が多い。 */
+export const MIN_DIGIT_COUNT = 3;
+
+const DIGIT_PATTERN = new RegExp(`\\d{${MIN_DIGIT_COUNT},}`, "g");
+
+export function extractIssueNumberCandidates(title: string): readonly string[] {
+	const matches = title.match(DIGIT_PATTERN);
+	if (matches === null) return [];
+	// 先頭ゼロ ("001") は Number.parseInt で 1 に潰れ、UI 表示 (チップ文字列) と
+	// mapping 書き込み値 (整数) で乖離が発生する。LinkSessionDialog の input も
+	// 先頭ゼロを invalid 扱いするため、候補提示の段階で除外する。
+	const withoutLeadingZero = matches.filter((m) => !m.startsWith("0"));
+	// Set で重複排除しつつ、挿入順 (出現順) を維持する。
+	const unique = Array.from(new Set(withoutLeadingZero));
+	return unique.slice(0, MAX_SUGGESTION_COUNT);
+}

--- a/src/sidepanel/usecase/merge-sessions.ts
+++ b/src/sidepanel/usecase/merge-sessions.ts
@@ -7,9 +7,14 @@ import type {
 import { extractSessionIdFromUrl } from "../../shared/utils/session-id";
 
 /**
- * ツリー配置決定済みのセッション。`isManuallyMapped` は UI バッジ表示用 (Epic #43)。
+ * ツリー配置決定済みのセッション。`isManuallyMapped` は UI バッジ表示用 (Epic #43)、
+ * `sessionId` は LinkSessionDialog 表示判定および手動マッピング書き込みキー (Issue #47)。
+ * URL から抽出できなかった場合は `null`。
  */
-type ResolvedSession = ClaudeSession & { readonly isManuallyMapped: boolean };
+type ResolvedSession = ClaudeSession & {
+	readonly isManuallyMapped: boolean;
+	readonly sessionId: string | null;
+};
 
 /**
  * 同一タイトルのセッションを重複排除し、各タイトルで代表 1 件のみ残す。
@@ -94,7 +99,7 @@ function resolveEffectivePlacement(
 			// なければ effective placement を諦める (どの Issue ノードにも合致しない)。
 			if (manualIssueNum === undefined && !hasValidRegexKey) continue;
 			const effectiveIssueNum = manualIssueNum ?? regexIssueNum;
-			const placed: ResolvedSession = { ...session, isManuallyMapped };
+			const placed: ResolvedSession = { ...session, isManuallyMapped, sessionId };
 			const bucket = result.get(effectiveIssueNum);
 			if (bucket) {
 				bucket.push(placed);
@@ -142,6 +147,8 @@ function mergeSessionsIntoNode(
 				// (手動マッピングで移動したセッションは移動先を指す)
 				issueNumber,
 				isManuallyMapped: s.isManuallyMapped,
+				// URL 抽出結果をそのまま伝播。壊れた URL は null で UI 側が Link ボタンを隠す。
+				sessionId: s.sessionId,
 			},
 			children: [] as readonly TreeNodeDto[],
 			depth: node.depth + 1,

--- a/src/test/shared/utils/workspace-resources.test.ts
+++ b/src/test/shared/utils/workspace-resources.test.ts
@@ -52,6 +52,7 @@ function createSessionChild(url: string, issueNumber: number): TreeNodeDto {
 			url,
 			issueNumber,
 			isManuallyMapped: false,
+			sessionId: null,
 		},
 		children: [],
 		depth: 2,

--- a/src/test/sidepanel/components/LinkSessionDialog.test.ts
+++ b/src/test/sidepanel/components/LinkSessionDialog.test.ts
@@ -1,0 +1,279 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// LinkSessionDialog.svelte は Phase 3 の GREEN フェーズで新規作成される。
+// svelte-check はプロジェクト設定上、未解決モジュールの import を型エラー扱いしないため
+// 通常 import で記述する。vitest 実行時にはモジュール解決が走り、
+// 未作成のためテストが全て RED (失敗) になる。
+import LinkSessionDialog from "../../../sidepanel/components/LinkSessionDialog.svelte";
+
+/**
+ * LinkSessionDialog の単体テスト (Phase 3 / Issue #47)。
+ *
+ * このダイアログは TreeNode の session 分岐から開かれ、
+ * ユーザーが Issue 番号を手動入力してセッションを任意 Issue に紐付ける。
+ *
+ * Props 設計:
+ *   - title:      入力済みセッションタイトル (サジェスト候補抽出元)
+ *   - sessionId:  紐付け対象のセッション ID (SESSION_ID_PATTERN 準拠)
+ *   - onClose:    閉じる要求コールバック (Esc / キャンセル / 送信完了時)
+ *   - setMapping: chrome.storage 書き込み関数 (DI 設計でテスタビリティを優先)
+ *
+ * テスト全体がモジュール未存在により RED となる。
+ */
+
+describe("LinkSessionDialog", () => {
+	let component: ReturnType<typeof mount> | null = null;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+			component = null;
+		}
+		document.body.innerHTML = "";
+	});
+
+	function defaultProps(
+		overrides: Partial<{
+			title: string;
+			sessionId: string;
+			onClose: () => void;
+			setMapping: (sessionId: string, issueNumber: number) => Promise<void>;
+		}> = {},
+	) {
+		return {
+			title: overrides.title ?? "Fix #123 related to 456",
+			sessionId: overrides.sessionId ?? "session_abcdef123456",
+			onClose: overrides.onClose ?? vi.fn(),
+			setMapping: overrides.setMapping ?? vi.fn(async () => {}),
+		};
+	}
+
+	it("title/sessionId を Props で渡してマウントできる", () => {
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps(),
+		});
+		const dialog = document.querySelector(".link-session-dialog");
+		expect(dialog).not.toBeNull();
+	});
+
+	it("title から抽出したサジェストチップが最大 5 件描画される", () => {
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ title: "111 222 333 444 555 666 777" }),
+		});
+		const chips = document.querySelectorAll(".issue-suggest-chip");
+		expect(chips.length).toBeLessThanOrEqual(5);
+		expect(chips.length).toBe(5);
+	});
+
+	it("サジェストチップをクリックすると input にその数字が入る", () => {
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ title: "Fix #123" }),
+		});
+		const chip = document.querySelector(".issue-suggest-chip") as HTMLElement | null;
+		expect(chip).not.toBeNull();
+		chip?.click();
+		const input = document.querySelector(".issue-number-input") as HTMLInputElement | null;
+		expect(input).not.toBeNull();
+		expect(input?.value).toBe("123");
+	});
+
+	it("空 input で submit しても setMapping は呼ばれない", () => {
+		const setMapping = vi.fn(async () => {});
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ setMapping }),
+		});
+		const form = document.querySelector(".link-session-form") as HTMLFormElement | null;
+		expect(form).not.toBeNull();
+		form?.requestSubmit();
+		expect(setMapping).not.toHaveBeenCalled();
+	});
+
+	it("不正な値 (0 / 先頭ゼロ / 負数 / 非数値 / 小数) では setMapping は呼ばれない", () => {
+		const setMapping = vi.fn(async () => {});
+		// Phase 4 レビュー CRITICAL-1: "001" のような先頭ゼロは Number.parseInt で 1 に
+		// 縮退する。UI 表示と実際の書き込み値が乖離するため invalid として弾く。
+		const invalidValues = ["0", "001", "-1", "abc", "1.5"];
+		for (const value of invalidValues) {
+			// 各ケースで独立に mount/unmount する (テスト間で DOM 状態を分離)
+			const localComponent = mount(LinkSessionDialog, {
+				target: document.body,
+				props: defaultProps({ setMapping }),
+			});
+			const input = document.querySelector(".issue-number-input") as HTMLInputElement | null;
+			const form = document.querySelector(".link-session-form") as HTMLFormElement | null;
+			expect(input).not.toBeNull();
+			expect(form).not.toBeNull();
+			if (input) {
+				input.value = value;
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+			}
+			form?.requestSubmit();
+			unmount(localComponent);
+			document.body.innerHTML = "";
+		}
+		expect(setMapping).not.toHaveBeenCalled();
+	});
+
+	it("正当な入力 + submit で setMapping(sessionId, number) が 1 回呼ばれ、その後 onClose が呼ばれる", async () => {
+		const setMapping = vi.fn(async () => {});
+		const onClose = vi.fn();
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({
+				sessionId: "session_testmapping01",
+				setMapping,
+				onClose,
+			}),
+		});
+		const input = document.querySelector(".issue-number-input") as HTMLInputElement | null;
+		expect(input).not.toBeNull();
+		if (input) {
+			input.value = "42";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		}
+		const form = document.querySelector(".link-session-form") as HTMLFormElement | null;
+		expect(form).not.toBeNull();
+		form?.requestSubmit();
+		// setMapping が await されるため micro task を流す
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(setMapping).toHaveBeenCalledTimes(1);
+		expect(setMapping).toHaveBeenCalledWith("session_testmapping01", 42);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("Esc キー押下で onClose が呼ばれる", () => {
+		const onClose = vi.fn();
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ onClose }),
+		});
+		const dialog = document.querySelector(".link-session-dialog") as HTMLElement | null;
+		expect(dialog).not.toBeNull();
+		const escEvent = new KeyboardEvent("keydown", {
+			key: "Escape",
+			bubbles: true,
+			cancelable: true,
+		});
+		(dialog ?? document).dispatchEvent(escEvent);
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("キャンセルボタンで onClose が呼ばれ、setMapping は呼ばれない", () => {
+		const setMapping = vi.fn(async () => {});
+		const onClose = vi.fn();
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ setMapping, onClose }),
+		});
+		const cancel = document.querySelector(".cancel-btn") as HTMLElement | null;
+		expect(cancel).not.toBeNull();
+		cancel?.click();
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(setMapping).not.toHaveBeenCalled();
+	});
+
+	it("overlay クリックでは閉じない (onClose が呼ばれない)", () => {
+		const onClose = vi.fn();
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({ onClose }),
+		});
+		const overlay = document.querySelector(".link-session-overlay") as HTMLElement | null;
+		expect(overlay).not.toBeNull();
+		overlay?.click();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	// HIGH-2 (Phase 3b レビュー指摘): setMapping が reject した場合、
+	// ダイアログ内にエラーを表示し、onClose は呼ばない。
+	// サイレントフォールバック (try/catch での握りつぶし) を検知するため、
+	// rejection 発生時に利用者がエラーを認識できる UI になっていることを保証する。
+	it("setMapping が reject した場合、エラー表示が出て onClose は呼ばれない", async () => {
+		const rejectionMessage = "storage quota exceeded";
+		const setMapping = vi.fn(async () => {
+			throw new Error(rejectionMessage);
+		});
+		const onClose = vi.fn();
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({
+				sessionId: "session_errortest0001",
+				setMapping,
+				onClose,
+			}),
+		});
+		const input = document.querySelector(".issue-number-input") as HTMLInputElement | null;
+		expect(input).not.toBeNull();
+		if (input) {
+			input.value = "7";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		}
+		const form = document.querySelector(".link-session-form") as HTMLFormElement | null;
+		expect(form).not.toBeNull();
+		form?.requestSubmit();
+		// setMapping の promise rejection がハンドリングされ、UI に反映されるまで
+		// micro task キューを数回流す (正常系の await パターンと揃える)。
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(setMapping).toHaveBeenCalledTimes(1);
+		expect(onClose).not.toHaveBeenCalled();
+
+		// エラー表示要素を検出する。
+		// 専用クラス `.link-session-error` またはエラー文言 (message の一部 or 「エラー」)
+		// のいずれかが DOM 上に存在すれば合格とする (実装の自由度を許容)。
+		const errorElement = document.querySelector(".link-session-error");
+		const bodyText = document.body.textContent ?? "";
+		const hasErrorText = bodyText.includes(rejectionMessage) || bodyText.includes("エラー");
+		expect(errorElement !== null || hasErrorText).toBe(true);
+	});
+
+	// HIGH-3 (Phase 3b レビュー指摘): submit 中の多重クリックで setMapping が
+	// 複数回呼ばれないこと (busy state による多重 submit ガード) を保証する。
+	// 同じ sessionId への不要な書き込み / race condition を防ぐ。
+	it("submit 中に連続で requestSubmit しても setMapping は 1 回しか呼ばれない", async () => {
+		// Promise を外部から resolve できる形にして「処理中」状態を作る。
+		let resolve!: () => void;
+		const setMapping = vi.fn(
+			() =>
+				new Promise<void>((r) => {
+					resolve = r;
+				}),
+		);
+		component = mount(LinkSessionDialog, {
+			target: document.body,
+			props: defaultProps({
+				sessionId: "session_busystate00001",
+				setMapping,
+			}),
+		});
+		const input = document.querySelector(".issue-number-input") as HTMLInputElement | null;
+		expect(input).not.toBeNull();
+		if (input) {
+			input.value = "9";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		}
+		const form = document.querySelector(".link-session-form") as HTMLFormElement | null;
+		expect(form).not.toBeNull();
+
+		// 3 回連続 submit (多重クリック相当)
+		form?.requestSubmit();
+		form?.requestSubmit();
+		form?.requestSubmit();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(setMapping).toHaveBeenCalledTimes(1);
+
+		// クリーンアップ: 保留中の promise を resolve してテスト終了時の
+		// unhandled pending promise を防ぐ。
+		resolve();
+		await Promise.resolve();
+	});
+});

--- a/src/test/sidepanel/components/MainScreen.session-merge.test.ts
+++ b/src/test/sidepanel/components/MainScreen.session-merge.test.ts
@@ -1,0 +1,143 @@
+import { mount, tick, unmount } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EpicTreeDto } from "../../../domain/ports/epic-processor.port";
+import type { ClaudeSessionStorage } from "../../../shared/types/claude-session";
+import MainScreen from "../../../sidepanel/components/MainScreen.svelte";
+import { resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+/**
+ * Phase 4 レビュー HIGH-3 回帰テスト:
+ * `mergeSessionsIntoTree` が「session 未マージ」のツリーを常に source にしていることを
+ * 保証する。過去のバグでは、既にセッションノードが append 済みの epicData を再マージに
+ * 渡していたため、mapping 変更イベントが発火するたびにセッションノードが累積していた。
+ *
+ * 本テストでは `subscribeToMappingChanges` の callback を複数回発火させ、
+ * issue ノードの children に含まれる session ノードが常に 1 件のみであることを検証する。
+ */
+
+function createTreeWithIssue(issueNumber: number): EpicTreeDto {
+	return {
+		roots: [
+			{
+				kind: {
+					type: "issue",
+					number: issueNumber,
+					title: `Issue ${issueNumber}`,
+					url: `https://github.com/o/r/issues/${issueNumber}`,
+					state: "OPEN",
+					labels: [],
+				},
+				children: [],
+				depth: 0,
+			},
+		],
+	};
+}
+
+function createSessionsForIssue(issueNumber: number): ClaudeSessionStorage {
+	return {
+		[String(issueNumber)]: [
+			{
+				title: `Work on #${issueNumber}`,
+				sessionUrl: "https://claude.ai/chat/01234567-89ab-cdef-0123-456789abcdef",
+				detectedAt: "2026-04-18T10:00:00.000Z",
+				issueNumber,
+				isLive: true,
+			},
+		],
+	};
+}
+
+describe("MainScreen session merge (HIGH-3 regression)", () => {
+	let component: ReturnType<typeof mount> | null = null;
+
+	beforeEach(() => {
+		setupChromeMock();
+	});
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+			component = null;
+		}
+		document.body.innerHTML = "";
+		resetChromeMock();
+	});
+
+	it("mapping change callback を複数回発火しても session ノードは重複しない", async () => {
+		const issueNumber = 555;
+		const tree = createTreeWithIssue(issueNumber);
+		const sessions = createSessionsForIssue(issueNumber);
+
+		const captured: { callback: (() => void) | null } = { callback: null };
+		const subscribeToMappingChanges = vi.fn((cb: () => void) => {
+			captured.callback = cb;
+			return vi.fn();
+		});
+
+		component = mount(MainScreen, {
+			target: document.body,
+			props: {
+				onLogout: vi.fn(async () => {}),
+				fetchPrs: vi.fn(async () => ({
+					myPrs: { items: [], totalCount: 0 },
+					reviewRequests: { items: [], totalCount: 0 },
+					reviewRequestBadgeCount: 0,
+					hasMore: false,
+				})),
+				fetchEpicTree: vi.fn(async () => ({ tree, prsRawJson: '{"data":{"myPrs":{"edges":[]}}}' })),
+				getClaudeSessions: vi.fn(async () => sessions),
+				getSessionIssueMappings: vi.fn(async () => ({})),
+				getCachedPrs: vi.fn(async () => ({
+					data: {
+						myPrs: { items: [], totalCount: 0 },
+						reviewRequests: { items: [], totalCount: 0 },
+						reviewRequestBadgeCount: 0,
+						hasMore: false,
+					},
+					lastUpdatedAt: "2026-04-18T10:00:00.000Z",
+				})),
+				loadPrsWithCache: vi.fn(async () => null),
+				subscribeToMessages: vi.fn((_cb: (message: unknown) => void) => vi.fn()),
+				subscribeToMappingChanges,
+				pinnedTabsStore: {
+					pinned: [],
+					activeKey: null,
+					loaded: true,
+					load: vi.fn(async () => {}),
+					pin: vi.fn(async () => {}),
+					unpin: vi.fn(async () => {}),
+					activate: vi.fn(async () => {}),
+				},
+				onNavigate: vi.fn(),
+				getCurrentTabUrl: vi.fn(async () => null),
+			},
+		});
+
+		// 初期マージ完了 (epicData が session 付きで埋まる) を待つ
+		// data-node-key のフォーマットは TreeNode.svelte / nodeKeyFor と揃える:
+		//   issue → `issue-${number}`
+		//   session → `session-${issueNumber}-${url}`
+		await vi.waitFor(() => {
+			expect(document.querySelectorAll(`[data-node-key="issue-${issueNumber}"]`).length).toBe(1);
+		});
+		await tick();
+
+		// 初期状態: session ノードが 1 件存在する
+		await vi.waitFor(() => {
+			expect(document.querySelectorAll('[data-node-key^="session-"]').length).toBe(1);
+		});
+
+		// subscribeToMappingChanges の callback を複数回発火
+		expect(captured.callback).not.toBeNull();
+		captured.callback?.();
+		captured.callback?.();
+		captured.callback?.();
+
+		// 再マージ後も session ノードは 1 件のまま (累積しない)
+		await vi.waitFor(() => {
+			const sessionNodes = document.querySelectorAll('[data-node-key^="session-"]');
+			expect(sessionNodes.length).toBe(1);
+		});
+	});
+});

--- a/src/test/sidepanel/components/TreeNode.test.ts
+++ b/src/test/sidepanel/components/TreeNode.test.ts
@@ -1,0 +1,107 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import type { TreeNodeDto } from "../../../domain/ports/epic-processor.port";
+import TreeNode from "../../../sidepanel/components/TreeNode.svelte";
+
+/**
+ * TreeNode の session 分岐に特化したテスト (Phase 3 / Issue #47)。
+ * 対象仕様:
+ *   - sessionId が抽出できるセッションには 🔗 Link ボタンが出る
+ *   - sessionId が null の場合は 🔗 ボタンが描画されない (壊れた URL への保護)
+ *   - 手動マッピング済みセッションには manual バッジが出る
+ *   - 🔗 ボタンクリックで LinkSessionDialog が DOM にマウントされる
+ *
+ * プロダクションコードはまだ上記を実装していないため、このテストは全て RED になる。
+ */
+
+function makeSessionNode(overrides: {
+	sessionId?: string | null;
+	isManuallyMapped?: boolean;
+	title?: string;
+	url?: string;
+}): TreeNodeDto {
+	// sessionId は `null` を意図的に渡せるようプロパティ存在チェックで分岐する。
+	// `overrides.sessionId ?? default` だと null でもデフォルトに置換されてしまい、
+	// 「sessionId: null のとき Link ボタン非表示」テストを正しく表現できない。
+	const sessionId = "sessionId" in overrides ? overrides.sessionId : "session_abcdef123456";
+	return {
+		kind: {
+			type: "session",
+			title: overrides.title ?? "Inv #123 session",
+			url: overrides.url ?? "https://claude.ai/code/session_abcdef123456",
+			issueNumber: 123,
+			isManuallyMapped: overrides.isManuallyMapped ?? false,
+			sessionId: sessionId ?? null,
+		} as TreeNodeDto["kind"],
+		children: [],
+		depth: 2,
+	};
+}
+
+describe("TreeNode (session 分岐)", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("sessionId が存在する session ノードには 🔗 Link ボタンが描画される", () => {
+		component = mount(TreeNode, {
+			target: document.body,
+			props: { node: makeSessionNode({ sessionId: "session_abcdef123456" }) },
+		});
+		const linkBtn = document.querySelector(".link-session-btn");
+		expect(linkBtn).not.toBeNull();
+	});
+
+	it("sessionId が null の session ノードには 🔗 Link ボタンが描画されない", () => {
+		component = mount(TreeNode, {
+			target: document.body,
+			props: {
+				node: makeSessionNode({
+					sessionId: null,
+					url: "https://claude.ai/code/malformed",
+				}),
+			},
+		});
+		const linkBtn = document.querySelector(".link-session-btn");
+		expect(linkBtn).toBeNull();
+	});
+
+	it("isManuallyMapped が true のとき manual バッジが描画される", () => {
+		component = mount(TreeNode, {
+			target: document.body,
+			props: { node: makeSessionNode({ isManuallyMapped: true }) },
+		});
+		const badge = document.querySelector(".manual-mapping-badge");
+		expect(badge).not.toBeNull();
+		// title 属性でマウスオーバー時にユーザーに意味を伝える
+		expect(badge?.getAttribute("title") ?? "").toContain("手動マッピング");
+	});
+
+	it("isManuallyMapped が false のとき manual バッジは描画されない", () => {
+		component = mount(TreeNode, {
+			target: document.body,
+			props: { node: makeSessionNode({ isManuallyMapped: false }) },
+		});
+		const badge = document.querySelector(".manual-mapping-badge");
+		expect(badge).toBeNull();
+	});
+
+	it("🔗 ボタンクリックで LinkSessionDialog が DOM に出現する", () => {
+		component = mount(TreeNode, {
+			target: document.body,
+			props: { node: makeSessionNode({ sessionId: "session_abcdef123456" }) },
+		});
+		// 初期状態ではダイアログは描画されていない
+		expect(document.querySelector(".link-session-dialog")).toBeNull();
+		const linkBtn = document.querySelector(".link-session-btn") as HTMLElement | null;
+		expect(linkBtn).not.toBeNull();
+		linkBtn?.click();
+		const dialog = document.querySelector(".link-session-dialog");
+		expect(dialog).not.toBeNull();
+	});
+});

--- a/src/test/sidepanel/usecase/extract-issue-number-candidates.test.ts
+++ b/src/test/sidepanel/usecase/extract-issue-number-candidates.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { extractIssueNumberCandidates } from "../../../sidepanel/usecase/extract-issue-number-candidates";
+
+/**
+ * LinkSessionDialog のサジェスト候補生成用 usecase のテスト。
+ * セッションタイトルから「Issue 番号っぽい数字」を抽出する。
+ *
+ * 仕様:
+ * - 3 桁以上の連続数字のみ拾う (2 桁以下はノイズ率が高いため除外)
+ * - 重複除去
+ * - 最大 5 件 (UI のチップ描画上限)
+ * - 空文字列や数字が無い場合は空配列
+ * - `#` や文字は数字抽出に影響しない
+ */
+describe("extractIssueNumberCandidates", () => {
+	it("単一の 3 桁以上の数字を抽出する", () => {
+		expect(extractIssueNumberCandidates("Fix #123")).toEqual(["123"]);
+	});
+
+	it("複数の 3 桁以上の数字を出現順に抽出する", () => {
+		expect(extractIssueNumberCandidates("Issue 456 related to 789")).toEqual(["456", "789"]);
+	});
+
+	it("2 桁以下の数字は除外する", () => {
+		// `12` はノイズ (日付・優先度など) の可能性が高いため除外される
+		expect(extractIssueNumberCandidates("Fix 12")).toEqual([]);
+	});
+
+	it("最大 5 件まで (先頭 5 件を保持)", () => {
+		expect(extractIssueNumberCandidates("111 222 333 444 555 666 777")).toEqual([
+			"111",
+			"222",
+			"333",
+			"444",
+			"555",
+		]);
+	});
+
+	it("重複する数字を除去する", () => {
+		expect(extractIssueNumberCandidates("#123 again #123")).toEqual(["123"]);
+	});
+
+	it("空文字列では空配列を返す", () => {
+		expect(extractIssueNumberCandidates("")).toEqual([]);
+	});
+
+	it("非数値文字 (`abc`, `##`) が混入していても数字のみ抽出する", () => {
+		expect(extractIssueNumberCandidates("abc ##123")).toEqual(["123"]);
+	});
+
+	// Phase 4 レビュー CRITICAL-1 / MEDIUM-2:
+	// 先頭ゼロの候補 ("001" 等) は Number.parseInt で 1 に潰れ、
+	// UI 表示 (input 値) と mapping 書き込み値で乖離が発生する。
+	// サジェスト段階で除外することで、ユーザーがチップを押しても
+	// 有効な submit 値になることを保証する。
+	it("先頭ゼロの数字は候補から除外する", () => {
+		expect(extractIssueNumberCandidates("Fix #001")).toEqual([]);
+	});
+
+	it("先頭ゼロの数字は除外し、有効なものだけを返す", () => {
+		expect(extractIssueNumberCandidates("Issue 100 related to 002")).toEqual(["100"]);
+	});
+});

--- a/src/test/sidepanel/usecase/find-node-in-tree.test.ts
+++ b/src/test/sidepanel/usecase/find-node-in-tree.test.ts
@@ -99,6 +99,7 @@ describe("findNodeInTree", () => {
 				url: "https://claude.ai/code/session_abc",
 				issueNumber: 500,
 				isManuallyMapped: false,
+				sessionId: "session_abc",
 			},
 			children: [],
 			depth: 2,
@@ -164,6 +165,7 @@ describe("nodeKeyFor", () => {
 				url: "https://claude.ai/code/session_abc",
 				issueNumber: 10,
 				isManuallyMapped: false,
+				sessionId: "session_abc",
 			}),
 		).toBe("session-10-https://claude.ai/code/session_abc");
 	});

--- a/src/test/sidepanel/usecase/merge-sessions.test.ts
+++ b/src/test/sidepanel/usecase/merge-sessions.test.ts
@@ -79,6 +79,70 @@ describe("mergeSessionsIntoTree", () => {
 			expect(issueNode.children[0].kind.title).toBe("Inv #10 fix tests");
 			expect(issueNode.children[0].kind.url).toBe("https://claude.ai/code/session-1");
 			expect(issueNode.children[0].kind.issueNumber).toBe(10);
+			// URL が `session_XXX` パターンに合致しないため sessionId は null になる
+			// sessionId フィールドは Phase 3 で TreeNodeKind に追加される予定。
+			// 追加前は型に存在しないため unknown 経由でアクセスし、実行時 undefined で
+			// null 比較が失敗することで RED を成立させる。
+			expect(
+				(issueNode.children[0].kind as unknown as { sessionId: string | null }).sessionId,
+			).toBeNull();
+		}
+	});
+
+	// Phase 3 (Issue #47): sessionId フィールドを session ノードに埋める
+	it("正常な URL から sessionId を抽出して session ノードに載せる", () => {
+		const tree: EpicTreeDto = {
+			roots: [makeEpicNode(1, [makeIssueNode(10)])],
+		};
+		const sessions: ClaudeSessionStorage = {
+			"10": [
+				{
+					sessionUrl: "https://claude.ai/code/session_abc123def456",
+					title: "Inv #10",
+					issueNumber: 10,
+					detectedAt: "2026-04-01T00:00:00Z",
+					isLive: true,
+				},
+			],
+		};
+
+		const result = mergeSessionsIntoTree(tree, sessions, {});
+
+		const issueNode = result.roots[0].children[0];
+		expect(issueNode.children).toHaveLength(1);
+		const child = issueNode.children[0];
+		expect(child.kind.type).toBe("session");
+		if (child.kind.type === "session") {
+			expect((child.kind as unknown as { sessionId: string | null }).sessionId).toBe(
+				"session_abc123def456",
+			);
+		}
+	});
+
+	it("不正な URL からは sessionId が null になる", () => {
+		const tree: EpicTreeDto = {
+			roots: [makeEpicNode(1, [makeIssueNode(10)])],
+		};
+		const sessions: ClaudeSessionStorage = {
+			"10": [
+				{
+					sessionUrl: "https://example.com/foo",
+					title: "Inv #10",
+					issueNumber: 10,
+					detectedAt: "2026-04-01T00:00:00Z",
+					isLive: false,
+				},
+			],
+		};
+
+		const result = mergeSessionsIntoTree(tree, sessions, {});
+
+		const issueNode = result.roots[0].children[0];
+		expect(issueNode.children).toHaveLength(1);
+		const child = issueNode.children[0];
+		expect(child.kind.type).toBe("session");
+		if (child.kind.type === "session") {
+			expect((child.kind as unknown as { sessionId: string | null }).sessionId).toBeNull();
 		}
 	});
 


### PR DESCRIPTION
## 概要
Epic #43 Phase 3。Sidebar の Claude session ノードに 🔗 Link ボタンと Issue 番号入力ダイアログを追加し、タイトル regex で拾えないセッションを手動で任意の Issue 配下に配置できるようにする。

## 変更内容
- **`src/sidepanel/components/LinkSessionDialog.svelte`** (新規): overlay ダイアログ UI。候補チップ (最大 5 件) + input + Esc キー + 初期フォーカス + multi-dialog 対応の keydown ハンドラ + submit 中 unmount 耐性 (`mounted` フラグ) + busy state による多重 submit 防止 + setMapping reject 時のエラー表示
- **`src/sidepanel/usecase/extract-issue-number-candidates.ts`** (新規): タイトルから `\d{3,}` で候補抽出 (先頭ゼロ除外、重複除去、先頭 5 件)
- **`src/shared/utils/session-mapping-subscribe.ts`** (新規): `chrome.storage.onChanged` → `sessionIssueMapping` キー変更購読 wrapper
- **`src/sidepanel/components/TreeNode.svelte`**: session 分岐に 🔗 ボタン + manual バッジ + LinkSessionDialog マウント
- **`src/sidepanel/components/MainScreen.svelte`**: `treeWithPrs` を `$state` で保持して再マージ source に (session ノード累積バグ防止)、`reloadSessionsAndMapping` 共通関数化で mapping change / session update の両リスナーから冪等に再マージ
- **`src/sidepanel/usecase/merge-sessions.ts`**: session child 生成時に `sessionId` を伝播
- **`src/domain/ports/epic-processor.port.ts`**: `TreeNodeKind.session` に `sessionId: string \| null` 追加
- **`rust-core/crates/domain/src/epic.rs`**: `TreeNodeKind::Session` に `session_id: Option<String>` 追加 (`#[serde(rename = "sessionId", default)]`、`skip_serializing_if` なし → `None` は `"sessionId":null` で出力)
- `src/sidepanel/main.ts` / `App.svelte`: subscribe module を wire up (Props 注入)

## 関連 Issue
- closes #47
- refs #43 (Epic)

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check` — 0 errors)
- [x] フロントエンドテスト通過 (`pnpm test` — 890 passed, 5 skipped、1 failed は既存 dep-cruiser TreeNode 自己循環誤検知で本 PR と無関係)
- [x] Rust lint 通過 (`cargo clippy --all-targets -- -D warnings` — 0 warnings)
- [x] Rust テスト通過 (`cargo test --workspace` — 76 passed)
- [x] `/verify` 検証ループ PASS (Tests / Security / Diff 全 OK)

追加テスト: 25 ケース
- `LinkSessionDialog.test.ts`: 11 ケース (マウント、候補チップ、valid/invalid 入力、submit, Esc, cancel, overlay 非クローズ、reject 時エラー表示、多重 submit ガード)
- `TreeNode.test.ts`: 5 ケース (🔗 ボタン有無、manual バッジ、ダイアログ開閉)
- `MainScreen.session-merge.test.ts`: HIGH-3 累積バグ回帰テスト (mapping change 3 回発火で session 重複しないこと)
- `extract-issue-number-candidates.test.ts`: 7+2 ケース (基本抽出、5 件上限、重複除去、先頭ゼロ除外)
- `merge-sessions.test.ts`: +2 ケース (sessionId 伝播 / null 伝播)
- `epic.rs`: +3 ケース (camelCase / legacy / None→null round-trip)

## レビュー観点 (4 agent レビュー済み)
本 PR は `/review` で 4 agent 並列レビュー → Phase 5 修正ラウンドを経ている。初回レビュー指摘は全解消 (再レビューで APPROVE)。

- **HIGH-3 (quality)**: `mergeSessionsIntoTree(epicData, ...)` の二重マージで session ノードが累積するバグを修正 (`treeWithPrs` を source として保持)。回帰テスト追加済み
- **HIGH-1 (quality)**: Esc キーを `window` でなく dialog 要素に登録することで複数 dialog 同時オープン時の暴発を防止
- **HIGH-2 (quality)**: submit 中 unmount 時の destroyed state 書き込みを `mounted` フラグでガード
- **CRITICAL-1 (quality)**: 先頭ゼロ入力 (`"001"` → 書き込み `1`) の UI/書き込み不一致を `INTEGER_PATTERN = /^[1-9]\d*$/` + 候補 filter で防止
- **MEDIUM (security)**: `import.meta.env.DEV` ガード下のサイレントフォールバックを撤去し本番でも console.error + epicError 表示

### フォローアップ (別 Issue 候補)
- MainScreen `loadPrs` の catch で `console.error` 欠落 (既存コード)
- `reloadSessionsAndMapping` 並行実行時の race (実害は小さい、debounce 未導入)
- `mergeSessionsIntoTree` のフルツリー再構築 debounce (現在規模では誤差)
- 完全な focus trap (現在は初期フォーカスのみの最低限対応)
- dep-cruiser の Svelte 5 再帰コンポーネント自己循環誤検知