### PR TITLE
chore: 個人環境固有の untracked ファイルを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 .env.local
 .env.*.local
 .claude/settings.local.json
+.claude/.tool-failure-streak
+.claude/.tool-failure-streak.lock
+.claude/mockups/
+.claude/worktrees/
+.superpowers/
+*.un~
 
 node_modules/
 dist/


### PR DESCRIPTION
## 概要
個人環境で生成される hook artifact / brainstorm state / vim swap 等が untracked として常時表示される状態を解消する。

## 変更内容
- `.gitignore` に以下のパターンを追加:
  - `.claude/.tool-failure-streak` (hook の連続失敗カウンタ)
  - `.claude/.tool-failure-streak.lock` (上記のロック)
  - `.claude/mockups/` (ローカル UI モック置き場)
  - `.claude/worktrees/` (ローカル git worktree 置き場)
  - `.superpowers/` (superpowers brainstorm の状態ファイル)
  - `*.un~` (vim undo ファイル)

## 関連 Issue
- なし — 環境ハウスキーピング (Issue #51 作業中に発覚し、独立して取り出した)

## テスト
- [x] 既存ファイルの追跡状態に影響なし (新規 ignore のみ)
- [ ] TypeScript 型チェック通過 (`pnpm check`) — 本変更は対象外
- [ ] フロントエンドテスト通過 (`pnpm test`) — 本変更は対象外
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — 本変更は対象外
- [ ] Rust テスト通過 (`cargo test`) — 本変更は対象外

## レビュー観点
- 追加した ignore パターンが、CI/共同開発で必要なファイルを誤って隠していないかの確認
- `*.un~` のように汎用的なパターンが、他の意図あるファイルを巻き込まないか
