### PR TITLE
fix(watcher): 末尾数字フォールバック削除、明示 prefix のみで抽出 (refs #43)

### DIFF
--- a/docs/adr/002-session-issue-mapping-prefix-only.md
+++ b/docs/adr/002-session-issue-mapping-prefix-only.md
@@ -1,0 +1,78 @@
+# ADR-002: Claude Code Web セッション → Issue 番号マッピングは明示 prefix のみで行う
+
+**Status**: Accepted
+**Date**: 2026-05-01
+**関連 Issue**: #3268
+
+## Context
+
+PR Sidebar は Claude Code Web のタブタイトルから Issue 番号を抽出し、Side Panel の tree に紐付けて表示する機能を持つ (`src/background/claude-session-watcher.ts` の `extractIssueNumberFromTitle`)。
+
+抽出ロジックは当初「タイトル中の任意の数字を文脈から推測する」発想で実装され、運用で発覚した取りこぼしのたびに正規表現を継ぎ足してきた。結果として 4 連続でデグレを発生させている。
+
+| Issue | 取りこぼした入力 | 追加した regex |
+|---|---|---|
+| #34 | 同一 sessionUrl が別 Issue key に残存 (cross-issue 重複) | (regex ではなく storage GC ロジックで対処) |
+| #40 | `playwright codegenみたいなのEpic 2576` ("Epic N" 形式) | `epic\s+(\d+)` |
+| #42 | `Context Rot対策 2598` (キーワードなし末尾数字) | `(?:^|\s)(\d{3,})(?:\s*\|.*)?$` |
+| #3268 | `[sdk] libclang のBlackSmith検証3268①` (日本語境界 + 丸付き数字 suffix) | — (前境界が日本語、後ろが ① で末尾 fallback でも未マッチ) |
+
+末尾数字 fallback (#42 由来) は「日本語境界」「全角文字」「丸付き数字 suffix」「英数字混在」など想定外の境界条件で破綻する。境界を緩めれば年号・バージョン・無関係数字を誤検出するため、自由形式タイトルを regex で網羅すること自体が破綻している。
+
+業界標準を確認したところ、主要な Issue/PR 自動リンク機能はすべて **明示 prefix を要求する設計** を採用している:
+
+| ツール | 形式 | 出典 |
+|---|---|---|
+| GitHub Autolink | `#NNN`, `GH-NNN`, `owner/repo#NNN` | [Autolinked references and URLs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) |
+| Jira Smart Commits | `[A-Z]{2,}-\d+` (例: `PROJ-123`) | [Atlassian Smart Commits](https://support.atlassian.com/jira-software-cloud/docs/process-issues-with-smart-commits/) |
+| Linear Magic Links | `TEAM-NNN` (branch 名・PR タイトル) | [Linear GitHub Integration](https://linear.app/docs/github-integration) |
+| VSCode GitHub PRs/Issues 拡張 | `#` 入力後に既知 Issue リスト照合 (ハイブリッド) | [IssueFeatures.md](https://github.com/microsoft/vscode-pull-request-github/blob/main/documentation/IssueFeatures.md) |
+
+「自由形式テキストから fuzzy 抽出する」設計は主要 OSS では採用例がない。
+
+## Decision
+
+`extractIssueNumberFromTitle` は **明示 prefix 3 種のみ** をサポートする:
+
+1. `#数字` (例: `Inv #1882`, `BlackSmith検証#3268⓪`)
+2. `issue 数字` (大小不問、例: `Investigate issue 2185`)
+3. `epic 数字` (大小不問、例: `Epic 2576`)
+
+末尾数字 fallback (#42 で導入) は **削除** する。上記いずれにもマッチしないタイトルは `null` を返し、UI 側で「未紐付けセッション」として表示、既存の `LinkSessionDialog` (Issue #47) から手動紐付けに誘導する。
+
+セッションタイトルに `#NNN` を含める運用は、ユーザー側で Claude Code Web の自動タイトル生成スクリプト (`~/.claude/session-titles/`) に組み込む。
+
+## Consequences
+
+### ポジティブ
+
+- 過去 4 回のデグレ要因 (regex 継ぎ接ぎ) が構造的に消滅する
+- 業界標準 (GitHub/Jira/Linear) と整合する設計に統一される
+- 「未マッチは手動」という明確な fallback 経路により、自動抽出の誤検出リスクがゼロになる
+- regex のメンテナンスコストが下がる (3 パターンに固定)
+
+### ネガティブ
+
+- 既存セッションタイトルに `#NNN` を含めていない場合、自動抽出されなくなる (手動紐付け必須)
+- `Context Rot対策 2598` のような「末尾数字だけのタイトル」は今後 `null` を返す (ユーザーが `#2598` を含める運用への切替が必要)
+
+## Alternatives Considered
+
+1. **既知 Open Issue リストとの照合方式**: PR Sidebar が保持する既知 Issue 番号集合と title 中の数字を intersection する。
+   - 却下理由: クロスリポ衝突 (同番号が複数 repo で Open)、複数候補の tie-break 規約、API fetch 失敗時のサイレントフォールバック、過去の Closed Issue を遡及消滅させる、など新しい破綻軸を 3 つ以上追加する。AgentTeams (devils-advocate) で Critical 指摘あり。
+
+2. **末尾 fallback の境界条件をさらに広げる (日本語境界 + 丸付き数字 suffix 対応)**: `(?:^|\s|\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana})(\d{3,})(?:[①-⑳]|\s*\|.*)?$` のような拡張。
+   - 却下理由: 境界を緩めるほど誤検出 (年号・バージョン・無関係数字) が増える。過去 3 回と同じ「継ぎ接ぎ」パターンであり、デグレ 5 回目を確実に呼ぶ。
+
+3. **自動抽出を完全廃止し全件手動紐付け化**: regex を削除し `LinkSessionDialog` のみで運用。
+   - 却下理由: `#NNN` 形式のタイトルは過去 4 回一度も誤らせていない。自動化の利益を全面放棄するのは過剰反応。明示 prefix を持つタイトルは自動化を維持する妥当性がある。
+
+4. **LLM ベース抽出**: タイトルを LLM に投げて issue 番号を推論させる。
+   - 却下理由: Chrome 拡張の MV3 で外部 API 呼び出しコスト・レイテンシ・privacy リスクが過大。問題の規模に対し over-engineering。
+
+## References
+
+- AgentTeams 招集結果 (architect / devils-advocate / quality-reviewer / fact-checker 4 名、2026-05-01)
+- 過去デグレ Issue: #34, #40, #42
+- 関連実装 Issue: #45 (Storage CRUD), #46 (mergeSessionsIntoTree 統合), #47 (LinkSessionDialog UI)
+- agent-base 共通ルール: `~/agent-base/rules/general/rework-prevention.md` (機械的検知の必要性)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,3 +3,4 @@
 | 番号 | タイトル | ステータス | 日付 |
 |------|---------|-----------|------|
 | 001 | Device Flow では PKCE/state を使用しない | Accepted | 2026-03-22 |
+| 002 | Claude Code Web セッション → Issue 番号マッピングは明示 prefix のみで行う | Accepted | 2026-05-01 |

--- a/src/background/claude-session-watcher.ts
+++ b/src/background/claude-session-watcher.ts
@@ -27,46 +27,33 @@ function removeDuplicateUrlFromOtherKeys(
 /**
  * Claude Code Web のセッションタイトルから Issue 番号を抽出する。
  *
- * パターン:
- * - "Inv #1882 [#1613] CI/CD App統一" -> 1882
- * - "Investigate issue 2185" -> 2185
- * - "[close] issue 1966" -> 1966
- * - "Inv #2013 -> #2065 [#1671]..." -> 2013
- * - "playwright codegenみたいなのEpic 2576" -> 2576 (Issue #40)
+ * 方針 (Issue #3268, ADR 002-session-issue-mapping-prefix-only):
+ * 業界標準 (GitHub Autolink, Jira Smart Commits, Linear Magic Links) と同じく
+ * 明示 prefix を要求する設計に統一した。自由形式タイトルからの自然言語的抽出は
+ * 過去 #34/#40/#42/#3268 の 4 連続デグレを発生させたため廃止。
+ *
+ * 対応パターン (この順で先勝ち):
+ * - "#数字" (例: "Inv #1882", "#2013 -> #2065", "BlackSmith検証#3268⓪")
+ * - "issue 数字" 大小不問 (例: "Investigate issue 2185", "[close] issue 1966")
+ * - "epic 数字" 大小不問 (例: "...Epic 2576")
+ *
+ * 上記いずれにも該当しないタイトルは null。UI 側で未紐付けセッションとして表示し、
+ * LinkSessionDialog (Issue #47) から手動紐付けに誘導する。
  */
 export function extractIssueNumberFromTitle(title: string): number | null {
-	// "#数字" パターン (例: "Inv #1882", "#2013 -> #2065")
 	const hashMatch = /#(\d+)/.exec(title);
 	if (hashMatch) {
 		return Number(hashMatch[1]);
 	}
 
-	// "issue 数字" パターン — 大文字小文字不問 (例: "Investigate issue 2185")
 	const issueMatch = /issue\s+(\d+)/i.exec(title);
 	if (issueMatch) {
 		return Number(issueMatch[1]);
 	}
 
-	// "epic 数字" パターン — 大文字小文字不問 (例: "...Epic 2576")
-	// `#` や `issue` キーワードを含まない Epic タイトルをカバーする (Issue #40)
 	const epicMatch = /epic\s+(\d+)/i.exec(title);
 	if (epicMatch) {
 		return Number(epicMatch[1]);
-	}
-
-	// 末尾数字フォールバック — キーワードなしタイトル (例: "Context Rot対策 2598") を救済する (Issue #42)
-	// 語境界あり・3桁以上・末尾限定で誤検出を最小化。" | Claude Code" サフィックスは許容。
-	// フォールバック発動は logDebug で追跡可能にする (誤検出デバッグ用)。
-	const trailingMatch = /(?:^|\s)(\d{3,})(?:\s*\|.*)?$/.exec(title);
-	if (trailingMatch) {
-		const issueNumber = Number(trailingMatch[1]);
-		logDebug(
-			"info",
-			"watcher",
-			"extractIssueNumberFromTitle matched via trailing-digit fallback",
-			`title="${title}" → ${issueNumber}`,
-		).catch(() => {});
-		return issueNumber;
 	}
 
 	return null;

--- a/src/test/background/claude-session-watcher.test.ts
+++ b/src/test/background/claude-session-watcher.test.ts
@@ -65,35 +65,56 @@ describe("extractIssueNumberFromTitle", () => {
 		expect(extractIssueNumberFromTitle("Inv #1000 Epic 2576")).toBe(1000);
 	});
 
-	// Issue #42: キーワードなし末尾数字フォールバック
-	it("extracts from 'Context Rot対策 2598' (trailing digit, no keyword)", () => {
-		expect(extractIssueNumberFromTitle("Context Rot対策 2598")).toBe(2598);
+	// Issue #3268 (PR feature/fix-bug-3268): 末尾数字フォールバックを廃止し、明示 prefix
+	// (#NNN / issue NNN / epic NNN) のみで自動抽出する方針に転換した。
+	// 業界標準 (GitHub Autolink, Jira Smart Commits, Linear Magic Links) は prefix 必須型を採用しており、
+	// 自由形式タイトルから自然言語的に数字を抽出する設計は誤検出が多くデグレを繰り返したため。
+	// 詳細: docs/adr/002-session-issue-mapping-prefix-only.md
+	it("returns null for 'Context Rot対策 2598' (trailing digit without prefix is no longer extracted)", () => {
+		expect(extractIssueNumberFromTitle("Context Rot対策 2598")).toBeNull();
 	});
 
-	it("extracts from 'Context Rot対策 2598 | Claude Code' (with suffix)", () => {
-		expect(extractIssueNumberFromTitle("Context Rot対策 2598 | Claude Code")).toBe(2598);
+	it("returns null for 'Context Rot対策 2598 | Claude Code' (trailing digit without prefix)", () => {
+		expect(extractIssueNumberFromTitle("Context Rot対策 2598 | Claude Code")).toBeNull();
 	});
 
-	it("returns null for '2026 roadmap' (digit is not trailing)", () => {
+	it("returns null for '2026 roadmap'", () => {
 		expect(extractIssueNumberFromTitle("2026 roadmap")).toBeNull();
 	});
 
-	it("returns null for 'Plan for 2026 migration' (trailing is word)", () => {
+	it("returns null for 'Plan for 2026 migration'", () => {
 		expect(extractIssueNumberFromTitle("Plan for 2026 migration")).toBeNull();
 	});
 
-	// 語境界: "V2598" のように文字列内の数字は末尾フォールバックで拾わない
-	it("returns null for 'V2598' (no word boundary before digits)", () => {
+	it("returns null for 'V2598' (no prefix)", () => {
 		expect(extractIssueNumberFromTitle("V2598")).toBeNull();
 	});
 
-	// 2桁以下はフォールバック対象外 (既存 issue/epic パターンで拾われる範囲と衝突回避)
-	it("returns null for 'some title 42' (2 digits below threshold)", () => {
+	it("returns null for 'some title 42' (no prefix)", () => {
 		expect(extractIssueNumberFromTitle("some title 42")).toBeNull();
 	});
 
-	// 優先順確認: 末尾数字より # が優先
-	it("prioritizes '#N' over trailing digit fallback", () => {
+	// Issue #3268 デグレード再発防止 fixture: 日本語境界 + 丸付き数字 suffix のセッションタイトル。
+	// `#` prefix なしのタイトルは null となり、UI 側で「未紐付け」セクションに出して手動紐付けに誘導する想定。
+	it("returns null for '[sdk] libclang のBlackSmith検証3268①' (Japanese boundary + circled digit suffix without #)", () => {
+		expect(extractIssueNumberFromTitle("[sdk] libclang のBlackSmith検証3268①")).toBeNull();
+	});
+
+	// 同タイトルでも `#` を含めれば自動抽出される (運用で `#NNN` を含める方針)
+	it("extracts from '[sdk] libclang のBlackSmith検証#3268⓪' (with #, even with circled digit suffix)", () => {
+		expect(extractIssueNumberFromTitle("[sdk] libclang のBlackSmith検証#3268⓪")).toBe(3268);
+	});
+
+	it("extracts from '[codegen]P5 総合#2576⑤' (with #)", () => {
+		expect(extractIssueNumberFromTitle("[codegen]P5 総合#2576⑤")).toBe(2576);
+	});
+
+	it("extracts from '[ZodError] issue #3065①' (with #, prefers # over 'issue' keyword)", () => {
+		expect(extractIssueNumberFromTitle("[ZodError] issue #3065①")).toBe(3065);
+	});
+
+	// 優先順確認: 末尾数字より # が優先 (旧 fallback が発火していた場合のリグレッション fixture)
+	it("prioritizes '#N' when trailing digit also exists", () => {
 		expect(extractIssueNumberFromTitle("something #100 context 2598")).toBe(100);
 	});
 });


### PR DESCRIPTION
## 概要

Claude Code Web セッションタイトルから Issue 番号を抽出する `extractIssueNumberFromTitle` を、業界標準（GitHub Autolink / Jira Smart Commits / Linear Magic Links）に倣い **明示 prefix 必須型** に簡略化。過去 4 連続デグレ (#34/#40/#42 + Claude Code Web 末尾丸付き数字形式) の根本対策。

## 変更内容

- **`src/background/claude-session-watcher.ts`**: `extractIssueNumberFromTitle` から末尾数字 fallback (`(?:^|\s)(\d{3,})(?:\s*\|.*)?$`) を削除。対応パターンは `#NNN` / `issue NNN` / `epic NNN` の 3 種に縮退
- **`src/test/background/claude-session-watcher.test.ts`**: 過去デグレ事例 (#34/#40/#42 + 日本語境界 + 丸付き数字 suffix) を fixture 化。`Context Rot対策 2598` 系の旧 fallback 期待値を `null` に更新。Claude Code Web 実例 (`#3268⓪`, `#2576⑤`, `#3065①`) を追加して `#NNN` 形式が確実に拾えることを検証
- **`docs/adr/002-session-issue-mapping-prefix-only.md`** (新規): 4 連続デグレに至った経緯、業界標準調査 (GitHub/Jira/Linear/VSCode 拡張) の根拠、却下した代替案 (既知 Issue リスト照合 / 末尾 fallback 拡張 / 全件手動 / LLM 抽出) を記録
- **`docs/adr/README.md`**: ADR-002 のインデックス追加

## 関連 Issue

- refs #43 (Epic: Claude セッションと Issue 番号の手動リンク機能 — タイトル regex 依存を撤廃)

## テスト

- [x] TypeScript 型チェック通過 (`pnpm check` → 0 ERRORS, 8 WARNINGS は既存)
- [x] フロントエンドテスト通過 (`pnpm test src/test/background/claude-session-watcher.test.ts` → 49/49 PASS)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし
- [ ] `/verify` で検証ループ PASS

注: `pnpm test` 全体では `dependency-cruiser.test.ts` の 6 件が depcruise 環境問題で失敗するが main でも同じ状態で再現するため本 PR と無関係（事前に main checkout で確認済）。

## レビュー観点

1. **方針転換の妥当性**: ADR-002 の Decision/Alternatives Considered で「末尾 fallback 削除 + 未マッチは手動紐付け誘導」を選んだ判断（業界標準 GitHub/Jira/Linear と整合）に違和感がないか
2. **既存テスト fixture の意図変更**: `Context Rot対策 2598` を `null` 期待に切り替えたことで、運用上「セッションタイトルに `#NNN` を含める」前提を共有できているか
3. **未マッチセッションの導線**: `LinkSessionDialog` (Issue #47 で実装済) で手動紐付け可能なことを前提としており、UI 側に追加変更は不要だが見落としがないか確認希望
4. **observability**: 末尾 fallback 削除に伴い `logDebug("info", "watcher", "extractIssueNumberFromTitle matched via trailing-digit fallback", ...)` も削除済。consumer がいなかったため問題なし (RW-023 の learnings に整合)

## 後続作業（本 PR の射程外）

- 未紐付けセッション一覧セクションの UI 追加（既存 `LinkSessionDialog` を流用） → 別 Issue で起票検討
- Claude Code Web のセッションタイトル自動命名スクリプトに `#NNN` を含める運用ルール整備（agent-base 側）
