### PR TITLE
refactor: WorkspaceOpenRequest 型を shared/types に統合 (closes #13)

### DIFF
--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -5,8 +5,8 @@ import type { IssueApiPort } from "../domain/ports/issue-api.port";
 import type { IssueProcessorPort } from "../domain/ports/issue-processor.port";
 import type { PrProcessorPort } from "../domain/ports/pr-processor.port";
 import type { TabNavigationPort } from "../domain/ports/tab-navigation.port";
+import type { WorkspaceOpenRequest } from "../shared/types/workspace";
 import type { ClaudeSessionWatcher } from "./claude-session-watcher";
-import type { WorkspaceOpenRequest } from "./workspace-open.usecase";
 
 export type BadgeService = {
 	readonly updateBadge: (reviewRequestCount: number) => Promise<void>;

--- a/src/background/workspace-open.usecase.ts
+++ b/src/background/workspace-open.usecase.ts
@@ -1,15 +1,12 @@
 import type { ScreenBounds, WindowManagerPort } from "../domain/ports/window-manager.port";
+import type { WorkspaceOpenRequest } from "../shared/types/workspace";
+
+// WorkspaceOpenRequest は shared/types/workspace に統合 (Issue #13)。
+// 下流で本モジュール経由の型参照を維持するため re-export する。
+export type { WorkspaceOpenRequest };
 
 /** 配置済み判定の許容誤差 (px) */
 const POSITION_TOLERANCE = 20;
-
-export interface WorkspaceOpenRequest {
-	readonly issueNumber: number;
-	readonly issueUrl: string;
-	readonly prUrl: string | null;
-	readonly sessionUrl: string | null;
-	readonly senderWindowId: number;
-}
 
 export interface WorkspaceOpenSettings {
 	readonly getArrangeEnabled: () => Promise<boolean>;

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -4,6 +4,7 @@ import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
 import type { DebugLogEntry } from "../utils/debug-logger";
 import type { ClaudeSessionStorage } from "./claude-session";
+import type { WorkspaceOpenRequest } from "./workspace";
 
 export interface DebugState {
 	readonly claudeSessions: ClaudeSessionStorage;
@@ -41,13 +42,7 @@ export type RequestMap = {
 	NAVIGATE_TO_PR: { url: string };
 	GET_CLAUDE_SESSIONS: undefined;
 	GET_DEBUG_STATE: undefined;
-	OPEN_WORKSPACE: {
-		issueNumber: number;
-		issueUrl: string;
-		prUrl: string | null;
-		sessionUrl: string | null;
-		senderWindowId: number;
-	};
+	OPEN_WORKSPACE: WorkspaceOpenRequest;
 };
 
 /** メッセージタイプ → レスポンスデータのマッピング */

--- a/src/shared/types/workspace.ts
+++ b/src/shared/types/workspace.ts
@@ -1,0 +1,14 @@
+/**
+ * Workspace 操作のリクエスト型。
+ *
+ * messages.ts の RequestMap["OPEN_WORKSPACE"] と
+ * background/workspace-open.usecase.ts の WorkspaceOpenRequest は
+ * 同一フィールド群を別の型として二重保守していたため、本ファイルに統合する。
+ */
+export interface WorkspaceOpenRequest {
+	readonly issueNumber: number;
+	readonly issueUrl: string;
+	readonly prUrl: string | null;
+	readonly sessionUrl: string | null;
+	readonly senderWindowId: number;
+}


### PR DESCRIPTION
## 概要
\`messages.ts の RequestMap[\"OPEN_WORKSPACE\"]\` と \`background/workspace-open.usecase.ts の WorkspaceOpenRequest\` が同じフィールド群を別の型として二重保守されていた問題を解消。\`src/shared/types/workspace.ts\` に新設して一元管理する。

## 変更内容
- \`src/shared/types/workspace.ts\` (新規): \`WorkspaceOpenRequest\` interface を定義
- \`src/shared/types/messages.ts\`: \`RequestMap[\"OPEN_WORKSPACE\"]\` の inline 定義を削除し、\`WorkspaceOpenRequest\` を import して参照
- \`src/background/workspace-open.usecase.ts\`: 内部 interface 定義を削除し、\`shared/types/workspace\` から import + 下流互換のため re-export
- \`src/background/types.ts\`: \`workspace-open.usecase\` 経由ではなく \`shared/types/workspace\` から直接 import

## 関連 Issue
closes #13

## 注記
Issue 本文に記載のあった \`src/sidepanel/usecase/workspace-layout.usecase.ts\` および \`workspace-arrange.usecase.ts\` は本リポジトリに存在しないため (Issue 起票時から削除済み)、対象外とした。

## テスト
- [x] svelte-check: 0 errors
- [x] vitest: 890 件 PASS (6 件 fail は dependency-cruiser 未インストール環境依存)
- [ ] CI: 未設定 (#54 で対応予定)

## レビュー観点
- \`messages.ts\` から \`workspace-open.usecase.ts\` への循環依存にならないか — \`messages.ts\` は shared 配下、\`workspace-open.usecase.ts\` は background 配下で、どちらも shared/types/workspace を import するだけなので循環なし
- background/workspace-open.usecase.ts の re-export は下流互換のためだが、長期的には全 caller を shared/types に直接 import するよう移行するのが望ましい (今回は types.ts のみ移行)

## 統合ジャーニーAC
不要・理由: 内部リファクタリング (型統合のみ、振る舞い変更なし)